### PR TITLE
Added simple support for markdown classes, hacky atm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jade": "^1.8.1",
     "metalsmith": "^1.0.1",
     "metalsmith-collections": "^0.6.0",
+    "metalsmith-dom": "^1.0.2",
     "metalsmith-jade": "0.0.3",
     "metalsmith-markdown": "^0.2.1",
     "metalsmith-templates": "^0.6.0",


### PR DESCRIPTION
Laget en hacky liten greie for å fikse utvidelsen av markdown. Ikke grundig testet, men ser ut til å fungere. Litt nasty downside, builder komplett DOM for hver html-fil, akseptabelt?

Fikk det nettopp til å funke, tenker å gjøre det litt mer fleksibelt og legge til støtte for f.eks id.
