### PR TITLE
all text centered instead of blocks! fixed

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -28,12 +28,7 @@
 }
 html {
     font-family: PTSans, Arial, sans-serif;
-    text-align: center;
     background: #FFF;
-}
-body {
-  margin-left: auto;
-  margin-right: auto;
 }
 h1, h2 {
     font-size: 20px;


### PR DESCRIPTION
Ser ut som vi har mye unødvendig css. Forrige "fiks" fjernet `text-align: left` i _body_ som overridet `center-align: center` i _html_. Heh:P
