### PR TITLE
fix naive responsive (all) images

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -5,7 +5,7 @@
 @light-background: #B1DAAE;
 
 // responsive images
-img {
+figure > img {
   &:extend(.img-responsive);
 }
 // header


### PR DESCRIPTION
This fixes #45. If a image is included on a line of it's own:

```
![](img.png)
```
it's wrapped in `<figure>` after pandoc has converted it to html.