### PR TITLE
playlist in text files..

### DIFF
--- a/build.js
+++ b/build.js
@@ -8,7 +8,8 @@ var Metalsmith  = require('metalsmith'),
     relative    = require('metalsmith-relative'),
     define      = require('metalsmith-define'),
     marked      = require('marked'), // for md strings in YAML header
-    path        = require('path');
+    path        = require('path'),
+    getPlaylists = require('./playlist');
 
 
 /*
@@ -17,22 +18,14 @@ var Metalsmith  = require('metalsmith'),
 lessonRoot = '..';
 builderRoot = path.basename(__dirname);
 collections = ['computercraft', 'python', 'scratch', 'web'];
-
-
-/*
-* functions
-*/
-function playlistId(name){
-  // replace chars in playlist-name, so that it can be used as id or class
-  name = name.replace(/ /g, '_');
-  name = name.replace(/[,.-?]/g, '');
-  return name;
-}
+sourceFolder = 'src';
+playlistFolder = 'spillelister';
 
 
 /*
  * setup objects
  */
+// metadata
 var metadataOptions = [
   // template for lessons
   { pattern: path.join('*', '**', '*.md'),
@@ -42,23 +35,33 @@ var metadataOptions = [
     metadata: { template: 'scratch.jade' }},
 ];
 
+// ignores
 var ignoreOptions = [
   path.join('**', 'README.md'),
 ];
 
+// collections and playlists
 var collectionOptions = {};
+var playlists = {};
 collections.forEach(function(collection){
+  // options for collections
   var tmp = {};
   tmp.pattern = path.join(collection, '**', '*.md');
   tmp.sortBy = 'link';
   collectionOptions[collection] = tmp;
+
+  // playlists
+  collectionFolder = path.join(lessonRoot, sourceFolder, collection);
+  playlists[collection] = getPlaylists(collectionFolder, playlistFolder);
 });
 
+// defines available in template
 var defineOptions = {
-  playlistId: playlistId,
-  marked: marked
+  marked: marked,
+  playlists: playlists
 };
 
+// template
 var templateOptions = {
   engine: 'jade',
   directory: path.join(builderRoot, 'templates'),

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-zip": "^2.0.2",
     "jade": "^1.8.1",
     "jquery": "^2.1.3",
+    "lodash": "^2.4.1",
     "marked": "^0.3.2",
     "metalsmith": "^1.0.1",
     "metalsmith-collections": "^0.6.0",
@@ -30,7 +31,8 @@
     "metalsmith-relative": "^1.0.3",
     "metalsmith-templates": "^0.6.0",
     "napa": "^1.1.0",
-    "run-sequence": "^1.0.2"
+    "run-sequence": "^1.0.2",
+    "yaml-front-matter": "^3.2.3"
   },
   "napa": {
     "scratchblocks2": "blob8108/scratchblocks2#f6aecc77a9"

--- a/playlist.js
+++ b/playlist.js
@@ -1,0 +1,57 @@
+var fs = require('fs');
+var path = require('path');
+var lineReader = require('line-reader');
+var yaml = require('yaml-front-matter');
+var _ = require('lodash');
+
+/*
+ * helper functions
+ */
+function withPath(filename) {
+  // add path to filename
+  return path.join(this.root, filename);
+}
+
+function isPlaylist(filename) {
+  // if not directory and ends with .txt
+  return filename.match(/\.txt$/) &&
+         !fs.statSync(filename).isDirectory();
+}
+
+function getPlaylistObject(filename) {
+  var lessonFiles = fs.readFileSync(filename, {encoding: 'utf8'}).split('\n');
+  lessonFiles = _.compact(lessonFiles); // omit empty lines
+  lessonFiles = _.map(lessonFiles, withPath, {root: this.root});
+
+  var playlistObject = {};
+  playlistObject.name = path.basename(filename).replace('.txt', '');
+  playlistObject.lessons = _.map(lessonFiles, getFrontMatter);
+
+  return playlistObject;
+}
+
+function getFrontMatter(filename){
+  // return front matter of file, its filename and link
+  var content = fs.readFileSync(filename);
+
+  var frontMatter = yaml.loadFront(content);
+  frontMatter = _.omit(frontMatter, '__content');
+  frontMatter.filename = filename;
+  frontMatter.link = filename.replace('.md', '.html');
+
+  return frontMatter;
+}
+
+
+module.exports = function(root, playlistFolder){
+  var playlistRoot = path.join(root, playlistFolder);
+
+  // create a list of playlists
+  var playlistFiles = fs.readdirSync(playlistRoot);
+  playlistFiles = _.map(playlistFiles, withPath, {root: playlistRoot});
+  playlistFiles = _.filter(playlistFiles, isPlaylist);
+
+  var playlists = _.map(playlistFiles, getPlaylistObject, {root: root});
+
+  return playlists;
+};

--- a/templates/index.jade
+++ b/templates/index.jade
@@ -2,27 +2,27 @@ extends ./layout.jade
 
 //- Mixin for indexing lessons
 mixin collection(name, collection)
-  -var playlistPrinted = playlist || {};
   .col-sm-6.col-md-3(id=name)
     h2= name.charAt(0).toUpperCase() + name.substr(1)
+
+    //- all lessons which does not have `indexed: false`
     each lesson in collection
-      if lesson.published !== false
-        if !lesson.playlist
-          a(href=relative(lesson.link))
-            li.list-group-item= lesson.title
-        else
-          //- lesson is in a playlist
-          - var id = playlistId(lesson.playlist)
-          if !playlistPrinted[id]
-            //- first lesson in playlist
-            li.list-group-item.playlist(id=id)
-              span.glyphicon.glyphicon-play
-              |  #{lesson.playlist}
-            -playlistPrinted[id] = true;
-          a(href=relative(lesson.link))
-            li.list-group-item.playlist-item(style="display:none" class=id)
-              span.glyphicon.glyphicon-play-circle
-              = ' ' + lesson.title
+      if lesson.indexed !== false
+        a(href=relative(lesson.link))
+          li.list-group-item= lesson.title
+
+    //- playlists from text files in `playlistFolder`
+    each playlist in playlists[name]
+
+      li.list-group-item.playlist(id=playlist.id)
+        span.glyphicon.glyphicon-play
+        |  #{playlist.name}
+
+      each lesson in playlist.lessons
+        a(href=relative(lesson.link))
+          li.list-group-item.playlist-item(style="display:none" class=playlist.id)
+            span.glyphicon.glyphicon-play-circle
+            = ' ' + lesson.title
 
 
 block content


### PR DESCRIPTION
..so that one lesson can be in several playlists.

`.txt` files in [playlistFolder](https://github.com/arve0/codeclub_lesson_builder/blob/playlist/build.js#L22) should contain lines with path to lesson markdown file (relative to root of collection).

**Changes**
`published` in YAML is renamed to `indexed` to better reflect that the lesson can be omitted from index. This is useful for lessons that does not make sense when not in right context (should only be in playlist).