### PR TITLE
Fix broken link in format spec section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Gulp and metalsmith read files in parallel, which might cause trouble for some u
 
 # Specification
 This is in norwegian, but will be updated to english when project have reached are more stable state. Especially, we need:
-- format specification - should be very similar to [CodeClubUK format](//github.com/CodeClub/lesson_format/blob/master/FORMATTING.md)
+- format specification - should be very similar to [Code Club UK format](//github.com/CodeClub/curriculum_documentation/blob/master/projects.md#2-write-your-project)
 - description of builder internal workings
 
 ## Spesifikasjoner på norsk


### PR DESCRIPTION
I don’t know if this updated link is exactly equivalent… I don’t think an exact equivalent of the formatting guide exists anymore. You could point to https://github.com/CodeClub/lesson_format/blob/4161d95e/FORMATTING.md I guess.