### PR TITLE
support for external yaml tag, closes #66

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -65,7 +65,7 @@ Data types in use are these:
 - *Number:* Start with an integer. May use `.` for floats.
     - Example: `level: 1`
 - *Bool:* `true` or `false`.
-    - Example: `indexed: true`
+    - Example: `indexed: false`
 
 Lists is currently not used, but is easily mistaken with markdown links which
 have similar syntax.
@@ -86,8 +86,21 @@ have similar syntax.
   (instead of list).
     - Example: `author: "[Arve Seljebu](http://arve0.github.io)"`
 
-- **license** (*string with optional markdown*) : If another license then
-  CC-BY-SA-4.0 is wanted for the content, specify this in the license tag.
+- **external** (*string*) : URL to external resource. Nice for adding external
+  lessons to index:
+
+    ```
+    ---
+    title: An external lesson
+    level: 3
+    external: http://domain.org/path/lesson.html
+    ---
+    ```
+
+- **footer** (*string with optional markdown*) : Add text to the footer.
+
+- **indexed** (*bool*) : If `false`, hides lesson from index. Nice for lessons
+  that only makes sense when along with others.
 
 - **language** (*string*) : Language the lesson is written in. Should be an
   [IETF language tag](wp-ietf) which is a combination of language
@@ -95,6 +108,12 @@ have similar syntax.
   Examples:
   - `language: nb-NO` is language Norwegian bokmål, region Norway.
   - `language: en-GB` is language English, region Great Britain.
+
+- **license** (*string with optional markdown*) : If another license then
+  CC-BY-SA-4.0 is wanted for the content, specify this in the license tag.
+
+- **translator** (*string*) : Translator of lesson if translated from another
+  language.
 
 
 [wp-ietf]: http://en.wikipedia.org/wiki/IETF_language_tag

--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ You could read about the format in [FORMAT.md](FORMAT.md).
 - [x] Convert markdown to styled HTML
 - [x] Convert markdown to styled PDF
 - [x] Link-checker
-- [x] Automatic build with github webhooks
-- [x] Create zip-archives of all lessons
-- [x] Style scratch code
+- [x] Automatic build with [github webhooks](https://developer.github.com/webhooks/)
+- [x] Zip-archive of collections/courses
+- [x] Styled scratch code blocks
 - [x] Specify your own header and footer in [templates](templates)
 - [x] Watch files and re-render lesson upon changes (live-reload in browser)
 - [x] Create playlists and hide lessons from index
+- [x] Use material from other webpages with `external`-tag
 - [ ] Lesson tags
 - [ ] Sortable index with search
 - [ ] Support for several languages
-- [ ] Use material from other webpages with `external`-tag
 
 ### gulp tasks
-You can run all tasks with `./gulp taskname` when in the lesson repo, or with `gulp taskname` in 
+You can run all tasks with `./gulp taskname` when in the lesson repo, or with `gulp taskname` in
 *codeclub_lesson_builder*-folder if you have installed gulp [globally](https://docs.npmjs.com/cli/install).
 
 **list of gulp tasks**

--- a/templates/index.jade
+++ b/templates/index.jade
@@ -15,14 +15,18 @@ mixin collection(name, collection)
         .name= playlist.name
 
       each lesson in playlist.lessons
-        a(href=relative(lesson.link))
+        //- if external tag set, use that as link
+        -link = lesson.external || lesson.link
+        a(href=relative(link))
           li.playlist.lesson(style="display:none" class=playlist.id + ' level-' + lesson.level)
             = lesson.title
 
     //- all lessons which does not have `indexed: false`
     each lesson in collection
       if lesson.indexed !== false
-        a(href=relative(lesson.link))
+        //- if external tag set, use that as link
+        -link = lesson.external || lesson.link
+        a(href=relative(link))
           li.lesson(class='level-' + lesson.level)= lesson.title
 
 


### PR DESCRIPTION
Simple implementation of external tag. Puts lesson in index and links to external resource.

![cclb_external](https://cloud.githubusercontent.com/assets/4810521/6566260/fc8cfbde-c6b7-11e4-806e-dacadfcfd992.gif)
