### PR TITLE
plus3network/gulp-less#140

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-add-src": "^0.2.0",
     "gulp-autoprefixer": "^2.0.0",
     "gulp-concat": "^2.4.3",
-    "gulp-less": "^2.0.1",
+    "gulp-less": "^3.0.1",
     "gulp-minify-css": "^0.3.11",
     "gulp-uglify": "^1.0.2",
     "gulp-zip": "^2.0.2",


### PR DESCRIPTION
Fixes error message:
```
node_modules/gulp-less/index.js:68 }).done(undefined, cb); ^ TypeError: undefined is not a function at DestroyableTransform._transform
```