### PR TITLE
Browserify 2

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var concat      = require('gulp-concat');
 var autoprefixer = require('gulp-autoprefixer');
 var minify      = require('gulp-minify-css');
 var uglify      = require('gulp-uglify');
+var browserify = require('gulp-browserify');
 // archive
 var zip         = require('gulp-zip');
 var fs          = require('fs');
@@ -103,17 +104,31 @@ gulp.task('assets', function(){
       'assets/**/*',
       'node_modules/scratchblocks2/build/*/*.png',
       'node_modules/bootstrap/dist/*/glyphicons-halflings-regular.*',
-      'node_modules/jquery/dist/jquery.min.map'
     ])
     .pipe(gulp.dest(assetRoot));
 });
 
+
 /*
- * concat and uglify scripts
+ * browserify, concat and uglify scripts
  */
-gulp.task('js', function(){
+gulp.task('browserify', function() {
+  return gulp.src('scripts/**/*.js')
+  .pipe(browserify({
+    insertGlobals: true,
+    debug: true
+  }))
+  .pipe(uglify())
+  .pipe(concat('script.min.js'))
+  .pipe(gulp.dest(assetRoot));
+});
+
+
+/*
+ * concat and uglify vendor scripts
+ */
+gulp.task('js', ['browserify'], function(){
   return gulp.src([
-    'scripts/**/*.js',
     'node_modules/scratchblocks2/build/scratchblocks2.js',
     'node_modules/scratchblocks2/src/translations.js',
     'node_modules/bootstrap/js/tooltip.js'
@@ -122,7 +137,7 @@ gulp.task('js', function(){
   .pipe(addsrc.prepend([
     'node_modules/jquery/dist/jquery.min.js'
   ]))
-  .pipe(concat('script.min.js'))
+  .pipe(concat('vendor.min.js'))
   .pipe(gulp.dest(assetRoot));
 });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codeclub_lesson_builder",
   "version": "0.0.1",
-  "description": "build code club lessons to html",
+  "description": "build code club lessons to html and pdf",
   "main": "build.js",
   "dependencies": {
     "async-each": "^0.1.6",
@@ -14,6 +14,7 @@
     "gulp": "^3.8.10",
     "gulp-add-src": "^0.2.0",
     "gulp-autoprefixer": "^2.0.0",
+    "gulp-browserify": "^0.5.1",
     "gulp-concat": "^2.4.3",
     "gulp-less": "^3.0.1",
     "gulp-minify-css": "^0.3.11",
@@ -22,6 +23,7 @@
     "jade": "^1.8.1",
     "jquery": "^2.1.3",
     "lodash": "^3.3.1",
+    "lunr-no": "0.0.3",
     "marked": "^0.3.2",
     "merge-stream": "^0.1.7",
     "metalsmith": "1.3.x",

--- a/templates/layout.jade
+++ b/templates/layout.jade
@@ -39,5 +39,6 @@ html
               .note!= footer
 
 
+    script(src=relative("/assets/vendor.min.js"))
     script(src=relative("/assets/script.min.js"))
     block scripts


### PR DESCRIPTION
Code from browserify branch (thanks @kwrl), without whitespace fix and jquery via browserify. Will allow for:

```js
var lib = require('lib');
```

...in client code (e.g., in scripts/index.js).

Jquery is included in vendor scripts, as other libraries depends on jquery (which is not available as node modules).