### PR TITLE
windows gulp util

### DIFF
--- a/utils/gulp.bat
+++ b/utils/gulp.bat
@@ -1,2 +1,2 @@
 cd codeclub_lesson_builder
-node_modules\gulp\bin\gulp.js %*
+node node_modules\gulp\bin\gulp.js %*


### PR DESCRIPTION
gulp.js is not executable on windows and should be applied to node as a parameter.