### PR TITLE
JSON.parse searchIndex.json upon text retrival

### DIFF
--- a/scripts/search.js
+++ b/scripts/search.js
@@ -12,6 +12,10 @@ function downloadIndex(){
   if (global.index === undefined) {
     $.ajax(relative('searchIndex.json'))
       .done(function(data){
+        if (typeof(data) === 'string') {
+          // parse data if served as text string (local file)
+          data = JSON.parse(data);
+        }
         global.index = lunr.Index.load(data);
     });
   }


### PR DESCRIPTION
When opening index.html from file system, $.ajax(url) gives text (not JSON),
in that case, parse it to JSON.

NOTE: chrome will only allow XHR from file system if
      --allow-file-access-from-files is used