### PR TITLE
add YAML-tag `external` to courses (course/index.md)

### DIFF
--- a/templates/index.jade
+++ b/templates/index.jade
@@ -9,9 +9,10 @@ block content
   .courses
     each collection, name in collections
       -index = '/' + name + '/index.html'
-      -link = relative(index)
+      -link = _.find(collection, {link: index}).external
+      -if (!link) link = relative(index)
       -logo = relative('/' + name + '/logo-black.png')
       a(href=link)
         img(src=logo)
-        -realName = _.pluck(_.where(collection, {link: index}), 'title')
+        -realName = _.find(collection, {link: index}).title
         span= realName


### PR DESCRIPTION
When the `external` tag is set, a click on the course will redirect to the
specified url.

In example, one can add an external arduino course by creating `arduino/index.md`
with the contents:
```
---
title: Arduino
external: https://kodegenet.no/track/arduino
---
```

cc @tjesi