### PR TITLE
metalsmith build: bump highlight version

### DIFF
--- a/build.js
+++ b/build.js
@@ -140,9 +140,7 @@ module.exports = function build(callback, options){
   // highlight code - exclude scratch code blocks
   .use(branch()
     .pattern(['**/*.html', '!scratch/**/*.html']) // no highlight on scratch blocks
-    .use(highlight({
-      languages: ['java', 'python', 'lua', 'html', 'css', 'js'] // prevent bug in highlight.js < 8.5: https://github.com/isagalaev/highlight.js/issues/701
-    }))
+    .use(highlight())
   )
   // add file.link metadata (now files are .html)
   .use(filepath())

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "metalsmith": "1.3.x",
     "metalsmith-branch": "0.0.4",
     "metalsmith-changed": "^0.1.0",
-    "metalsmith-code-highlight": "0.0.2",
+    "metalsmith-code-highlight": "0.0.3",
     "metalsmith-collections": "^0.6.0",
     "metalsmith-define": "^1.0.0",
     "metalsmith-filemetadata": "0.0.4",


### PR DESCRIPTION
Previous highlight version (<8.5) had a bug which caused metalsmith build
to never finish (looping endless). This was fixed in highlight.js 8.5.

Ref: https://github.com/isagalaev/highlight.js/issues/701