### PR TITLE
force-build upon **/index.md changed

### DIFF
--- a/config.js
+++ b/config.js
@@ -32,6 +32,7 @@ var config = {
   // folder names
   playlistFolder: 'playlists',
   sourceFolder:   sourceFolder,
+  sourceRoot:     sourceRoot,
   // collections
   collections:    collections,
   // github webhook for automatic building

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -221,8 +221,8 @@ gulp.task('default', ['server'], function(){
    * ## WATCHES ##
    */
   // files which are built with metalsmith
-  gulp.watch(path.join(lessonRoot, sourceFolder, '**'), ['build', reload]);
-  gulp.watch(path.join(__dirname, 'templates', '**'), ['force-build', reload]);
+  gulp.watch([config.sourceRoot + '/**', '!' + config.sourceRoot + '/**/index.md'], ['build', reload]);
+  gulp.watch([__dirname + '/templates/**', config.sourceRoot + '/**/index.md'], ['force-build', reload]);
 
   // styles
   gulp.watch(path.join(__dirname, 'styles', '**', '*'), ['css', reload]);


### PR DESCRIPTION
All files should be built upon changes to `**/index.md` (course index and lesson indexes), so that collection metadata is correct (links to lesson files, etc).