### PR TITLE
bump metalsmith-pandoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "metalsmith-ignore": "^0.1.2",
     "metalsmith-jade": "0.0.3",
     "metalsmith-lunr": "^0.2.1",
-    "metalsmith-pandoc": "0.1.2",
+    "metalsmith-pandoc": "0.1.4",
     "metalsmith-paths": "^2.0.0",
     "metalsmith-relative": "^1.0.3",
     "metalsmith-templates": "^0.6.0",


### PR DESCRIPTION
fixes cmd.exe popups on windows

do `npm install` after merge