### PR TITLE
update gulp.bat to be equivalent to gulp bash script

### DIFF
--- a/utils/gulp.bat
+++ b/utils/gulp.bat
@@ -1,2 +1,19 @@
-cd codeclub_lesson_builder
-node node_modules\gulp\bin\gulp.js %*
+@echo off
+set CWD=codeclub_lesson_builder
+set MODULES=%CWD%/node_modules
+
+if not "%1"=="" goto task
+
+:: no args, run forever
+:gulp
+node %MODULES%/gulp/bin/gulp.js --cwd %CWD%
+if errorlevel 1 goto gulp
+goto done
+
+:task
+:: arg supplied, do not run forever
+node %MODULES%/gulp/bin/gulp.js --cwd %CWD% %*
+
+:done
+set CWD=
+set MODULES=

--- a/utils/setup.bat
+++ b/utils/setup.bat
@@ -1,0 +1,7 @@
+@echo off
+git submodule init
+git submodule update --depth 1
+cd codeclub_lesson_builder
+npm install
+cd ..
+pause


### PR DESCRIPTION
Improvement of gulp.bat, equivalent to gulp shell script.

- allow for specifying task
- runs gulp forever if exited with error code - uses simple scripting in favor of forever which has [annoying popups](https://github.com/foreverjs/forever/issues/732) on `child_process.spawn` (pandoc).