### PR TITLE
add style .video-container for iframe videos

### DIFF
--- a/styles/lesson.less
+++ b/styles/lesson.less
@@ -216,3 +216,19 @@ code {
     color: #fff;
   }
 }
+
+// embedded videos
+.video-container {
+  position: relative;
+  padding-bottom: 56.25%;  // 16:9
+  height: 0;
+  overflow: hidden;
+  margin: 30px 0 60px 0;
+  iframe {
+    position: absolute;
+    top:0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}


### PR DESCRIPTION
Use like this:

```html
Bla bla bla, paragraf...

<div class="video-container">
<iframe width="560" height="315" src="https://www.youtube.com/embed/JJQWtGm3eIs" frameborder="0" allowfullscreen></iframe>
</div>

bla bla
```

Note the space around the HTML.