### PR TITLE
Hanging on failed link

### DIFF
--- a/check-links.js
+++ b/check-links.js
@@ -73,7 +73,12 @@ module.exports = function(start) {
       function parseResponse(doc){
         // check status code
         var code = doc.res.statusCode;
-        if (code != 200) {
+        if (code !== 200 && this.opts.method === 'HEAD') {
+          // try again with GET-method
+          textSpider.queue(this.opts.url, parseResponse);
+          return;
+        }
+        if (code !== 200) {
           process.stdout.write('x'); // give some feedback
           broken += 1;
           failed.push({u:doc.url, c:code});
@@ -133,10 +138,10 @@ module.exports = function(start) {
       /**
        * on broken link
        */
-      function error(url, err) {
+      function error(err, url) {
           process.stdout.write('!'); // give some feedback
           broken += 1;
-          failed.push({u:url, c:err});
+          failed.push({u:url, c:err.code});
       }
 
       /**

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "metalsmith-relative": "^1.0.3",
     "metalsmith-templates": "^0.6.0",
     "napa": "^1.1.0",
-    "node-spider": "^1.2.2",
+    "node-spider": "arve0/node-spider",
     "nodepdf-series": "0.1.2",
     "run-sequence": "^1.0.2",
     "yaml-front-matter": "^3.2.3"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "metalsmith-relative": "^1.0.3",
     "metalsmith-templates": "^0.6.0",
     "napa": "^1.1.0",
-    "node-spider": "^1.2.1",
+    "node-spider": "^1.2.2",
     "nodepdf-series": "0.1.2",
     "run-sequence": "^1.0.2",
     "yaml-front-matter": "^3.2.3"


### PR DESCRIPTION
If node-spider fails on the last link in the queue, `gulp links` would never finish. This is fixed in node-spider 1.2.2.