### PR TITLE
Babel / es2015

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,7 +90,9 @@ gulp.task('browserify', function() {
     debug: true
   });
 
-  return b.bundle()
+  return b
+  .transform("babelify", {presets: ["es2015"]})
+  .bundle()
   .pipe(source('script.min.js'))
   .pipe(streamify(uglify()))
   .pipe(gulp.dest(config.assetRoot));

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
     "vinyl-source-stream": "^1.1.0",
     "yaml-front-matter": "^3.2.3"
   },
+  "devDependencies": {
+    "babel-preset-es2015": "^6.3.13",
+    "babelify": "^7.2.0"
+  },
   "napa": {
     "scratchblocks2": "tjvr/scratchblocks2#0ca7d46"
   },


### PR DESCRIPTION
Added babelify-transform to browserify so that scripts/index.js (and all the files that index.js includes) can be written using es2015 (es6).