### PR TITLE
Faster js build

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ You can run tasks with `./gulp taskname` when in the lesson repo, or with `gulp 
 - `build-search-index` builds `searchIndex.json` which is used for client-side search with [lunr](http://lunrjs.com)
 - `clean` delete all files in `build`
 - `css` will process less files, add asset-css, autoprefix, minify and concat to `style.min.css`
-- `js` uglify, add already uglified asset-js and concat to `script.min.js`
+- `js:client` browserify client scripts, entry point is [`scripts/index.js`]
+- `js:dist` same as `js:client`, but also uglify and create source maps
+- `js:vendor` concat vendor scripts
 - `pdf` will create PDFs of all htmls in build folder
 - `server` will start a local web-server and open your browser with the index
 - `default` start the `server`-task and reload browser upon file changes (runs when gulp recieves no arguments)

--- a/package.json
+++ b/package.json
@@ -4,10 +4,23 @@
   "description": "build code club lessons to html and pdf",
   "main": "build.js",
   "dependencies": {
+    "i18next": "^2.0.4",
+    "i18next-browser-languagedetector": "0.0.11",
+    "i18next-xhr-backend": "^0.1.0",
+    "intro.js": "^1.1.1",
+    "json5": "^0.4.0",
+    "jquery": "^2.1.3",
+    "js-cookie": "^2.0.4",
+    "moment": "^2.10.6"
+  },
+  "devDependencies": {
     "async-each": "^0.1.6",
-    "bootstrap": "^3.3.1",
+    "babel-core": "^6.3.26",
+    "babel-preset-es2015": "^6.3.13",
+    "babelify": "^7.2.0",
     "browser-sync": "^1.7.2",
     "browserify": "^11.2.0",
+    "bootstrap": "^3.3.1",
     "del": "^1.1.1",
     "forever": "^0.14.1",
     "githubhook": "^1.1.3",
@@ -22,12 +35,8 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.2",
     "highlight.js": "^8.9.1",
-    "i18next": "^2.0.4",
-    "i18next-xhr-backend": "^0.1.0",
-    "intro.js": "^1.1.1",
+    "i18next-sync-fs-backend": "0.1.0",
     "jade": "^1.11.0",
-    "jquery": "^2.1.3",
-    "js-cookie": "^2.0.4",
     "lodash": "^3.3.1",
     "lunr": "^0.5.9",
     "lunr-no": "0.0.3",
@@ -48,7 +57,6 @@
     "metalsmith-markdownit": "^0.1.3",
     "metalsmith-paths": "^2.0.0",
     "metalsmith-relative": "^1.0.3",
-    "moment": "^2.10.6",
     "napa": "^1.1.0",
     "node-spider": "^1.3.0",
     "node-static": "^0.7.7",
@@ -57,14 +65,6 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "yaml-front-matter": "^3.2.3"
-  },
-  "devDependencies": {
-    "babel-core": "^6.3.26",
-    "babel-preset-es2015": "^6.3.13",
-    "babelify": "^7.2.0",
-    "i18next-browser-languagedetector": "0.0.11",
-    "i18next-sync-fs-backend": "0.1.0",
-    "json5": "^0.4.0"
   },
   "napa": {
     "scratchblocks2": "tjvr/scratchblocks2#0ca7d46"

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "babel-core": "^6.3.26",
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",
+    "bootstrap": "^3.3.1",
     "browser-sync": "^1.7.2",
     "browserify": "^11.2.0",
-    "bootstrap": "^3.3.1",
     "del": "^1.1.1",
     "forever": "^0.14.1",
     "githubhook": "^1.1.3",
@@ -64,6 +64,7 @@
     "run-sequence": "^1.0.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.7.0",
     "yaml-front-matter": "^3.2.3"
   },
   "napa": {


### PR DESCRIPTION
- use watchify
- do not uglify dev build
- do not build vendor on scripts update
- rename gulp scripts:
  - js -> js:vendor
  - browserify -> js:client
- add gulp script: js:dist
- be strict about dependencies (client) and development dependencies