### PR TITLE
use standard code style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/*
 .DS_STORE
 build/*
 assets/css/*
+npm-debug.log

--- a/build-indexes.js
+++ b/build-indexes.js
@@ -1,23 +1,23 @@
 /**
  * build index files
  */
-var Metalsmith = require('metalsmith');
-var layouts = require('metalsmith-layouts');
-var collections = require('metalsmith-collections');
-var setMetadata = require('metalsmith-filemetadata');
-var filepath = require('metalsmith-filepath');
-var ignore = require('metalsmith-ignore');
-var relative = require('metalsmith-relative');
-var define = require('metalsmith-define');
-var _ = require('lodash');
-var paths = require('metalsmith-paths');
-var md = require('./markdown.js');
-var translate = require('./i18n.js');
+var Metalsmith = require('metalsmith')
+var layouts = require('metalsmith-layouts')
+var collections = require('metalsmith-collections')
+var setMetadata = require('metalsmith-filemetadata')
+var filepath = require('metalsmith-filepath')
+var ignore = require('metalsmith-ignore')
+var relative = require('metalsmith-relative')
+var define = require('metalsmith-define')
+var _ = require('lodash')
+var paths = require('metalsmith-paths')
+var md = require('./markdown.js')
+var translate = require('./i18n.js')
 // get configuration variables
-var config = require('./config.js');
-var tools = require('./tools.js');
-var playlists = require('./playlists.js');
-var lessonReadme = require('./lesson-readme.js');
+var config = require('./config.js')
+var tools = require('./tools.js')
+var playlists = require('./playlists.js')
+var lessonReadme = require('./lesson-readme.js')
 
 /**
  * # SETUP OBJECTS #
@@ -27,41 +27,41 @@ var metadataOptions = [
   // front page layout
   { pattern: 'index.md',
     metadata: { layout: 'index.jade' }}
-];
+]
 
 // ignore everything except index files
 var ignoreOptions = [
   '**',
   '!**/*.md',
   '**/README.md'
-];
+]
 
 // collections
-var collectionOptions = {};
-config.collections.forEach(function(collection){
+var collectionOptions = {}
+config.collections.forEach(function (collection) {
   // options for collections
   collectionOptions[collection] = {
     pattern: collection + '/**/*.md'
-  };
-});
-function sortCollections(courses) {
-  var out = [];
+  }
+})
+function sortCollections (courses) {
+  var out = []
   for (var name in courses) {
-    var course = {};
-    course.lessons = courses[name];
-    course.name = name;
-    out.push(course);
+    var course = {}
+    course.lessons = courses[name]
+    course.name = name
+    out.push(course)
   }
   out.sort(function (a, b) {
     if (a.lessons.length > b.lessons.length) {
-      return -1;
+      return -1
     }
     if (a.lessons.length < b.lessons.length) {
-      return 1;
+      return 1
     }
-    return 0;
+    return 0
   })
-  return out;
+  return out
 }
 
 // defines available in layout
@@ -73,21 +73,20 @@ var defineOptions = {
   matter: tools.frontmatter,
   t: translate,
   sort: sortCollections
-};
+}
 
 // layout
 var layoutOptions = {
   engine: 'jade',
   directory: config.builderRoot + '/layouts',
   default: 'lesson-index.jade'
-};
-
+}
 
 /**
  * # EXPORT #
  * build-function, calls callback when done
  */
-module.exports = function build(callback){
+module.exports = function build (callback) {
   // do the building
   Metalsmith(config.lessonRoot)
   .source(config.sourceFolder)
@@ -116,24 +115,24 @@ module.exports = function build(callback){
   .use(define(defineOptions))
   // apply layouts
   .use(layouts(layoutOptions))
-  //build
+  // build
   .destination('build')
-  .build(function(err){
-    if (err) console.log(err);
+  .build(function (err) {
+    if (err) console.log(err)
     // callback when build is done
-    callback(err);
-  });
-};
+    callback(err)
+  })
+}
 
 /**
  * remove files from build which have set indexed: false in frontmatter
  */
-function ignoreIndexedFalse(files, _, done) {
-  Object.keys(files).forEach(function(key){
-    var file = files[key];
+function ignoreIndexedFalse (files, _, done) {
+  Object.keys(files).forEach(function (key) {
+    var file = files[key]
     if (file.indexed === false) {
-      delete files[key];
+      delete files[key]
     }
-  });
-  done();
+  })
+  done()
 }

--- a/build-search-index.js
+++ b/build-search-index.js
@@ -1,39 +1,37 @@
 /**
  * build searchIndex.json
  */
-var Metalsmith = require('metalsmith');
-var ignore = require('metalsmith-ignore');
-var setMetadata = require('metalsmith-filemetadata');
-var lunr = require('lunr');
-require('lunr-no/lunr.stemmer.support')(lunr);
-require('lunr-no')(lunr);
-var metlunr = require('metalsmith-lunr');
-var config = require('./config.js');
+var Metalsmith = require('metalsmith')
+var ignore = require('metalsmith-ignore')
+var setMetadata = require('metalsmith-filemetadata')
+var lunr = require('lunr')
+require('lunr-no/lunr.stemmer.support')(lunr)
+require('lunr-no')(lunr)
+var metlunr = require('metalsmith-lunr')
+var config = require('./config.js')
 var tools = require('./tools.js')
 
 // lunr: true on all .md files
 var metadataOptions = [
   { pattern: '**/*.md',
-    metadata: { lunr: true }},
-];
+    metadata: { lunr: true } }
+]
 
 // for is not a stopword in this context
-var words = lunr.no.stopWordFilter.stopWords.elements;
-words.splice(words.indexOf('for'), 1);
+var words = lunr.no.stopWordFilter.stopWords.elements
+words.splice(words.indexOf('for'), 1)
 
 // ignore everything except .md files
 var ignoreOptions = [
   '**',
   '!**/*.md',
   '**/README.md'
-];
-
+]
 
 /**
  * build-function, calls callback when done
  */
-module.exports = function build(callback){
-
+module.exports = function build (callback) {
   // do the building
   Metalsmith(config.lessonRoot)
   .source(config.sourceFolder)
@@ -45,7 +43,7 @@ module.exports = function build(callback){
     fields: {
       contents: 1,
       title: 10,
-      tags: 20,
+      tags: 20
     },
     pipelineFunctions: [
       lunr.no.trimmer,
@@ -57,9 +55,9 @@ module.exports = function build(callback){
   .use(ignore(['**', '!searchIndex.json']))
   // put in build folder
   .destination('build')
-  .build(function(err){
-    if (err) console.log(err);
+  .build(function (err) {
+    if (err) console.log(err)
     // callback when build is done
-    callback(err);
-  });
-};
+    callback(err)
+  })
+}

--- a/build.js
+++ b/build.js
@@ -1,23 +1,23 @@
 /*
  * # DEPENDENCIES #
  */
-var Metalsmith = require('metalsmith');
-var layouts = require('metalsmith-layouts');
-var collections = require('metalsmith-collections');
-var setMetadata = require('metalsmith-filemetadata');
-var filepath = require('metalsmith-filepath');
-var ignore = require('metalsmith-ignore');
-var relative = require('metalsmith-relative');
-var define = require('metalsmith-define');
-var _ = require('lodash');
-var changed = require('metalsmith-changed');
-var paths = require('metalsmith-paths');
-var md = require('./markdown.js');
-var translate = require('./i18n.js');
+var Metalsmith = require('metalsmith')
+var layouts = require('metalsmith-layouts')
+var collections = require('metalsmith-collections')
+var setMetadata = require('metalsmith-filemetadata')
+var filepath = require('metalsmith-filepath')
+var ignore = require('metalsmith-ignore')
+var relative = require('metalsmith-relative')
+var define = require('metalsmith-define')
+var _ = require('lodash')
+var changed = require('metalsmith-changed')
+var paths = require('metalsmith-paths')
+var md = require('./markdown.js')
+var translate = require('./i18n.js')
 // get configuration variables
-var config = require('./config.js');
-var tools = require('./tools.js');
-var lessonReadme = require('./lesson-readme.js');
+var config = require('./config.js')
+var tools = require('./tools.js')
+var lessonReadme = require('./lesson-readme.js')
 
 /*
  * # SETUP OBJECTS #
@@ -30,22 +30,22 @@ var metadataOptions = [
   // scratch lesson layout
   { pattern: 'scratch/**/*.md',
     metadata: { layout: 'scratch.jade' }}
-];
+]
 
 // ignores
 var ignoreOptions = [
   'index.md',
   '*/index.md'
-];
+]
 
 // collections
-var collectionOptions = {};
-config.collections.forEach(function(collection){
+var collectionOptions = {}
+config.collections.forEach(function (collection) {
   // options for collections
   collectionOptions[collection] = {
     pattern: collection + '/**/*.md'
-  };
-});
+  }
+})
 
 // defines available in layout
 var defineOptions = {
@@ -55,22 +55,21 @@ var defineOptions = {
   isFile: tools.isFile,
   matter: tools.frontmatter,
   t: translate
-};
+}
 
 // layout
 var layoutOptions = {
   engine: 'jade',
   directory: config.builderRoot + '/layouts'
-};
-
+}
 
 /*
  * # EXPORT #
  * build-function which takes a callback
  */
-module.exports = function build(callback, options){
-  options = options || {};
-  var forceBuild = options.force || false;
+module.exports = function build (callback, options) {
+  options = options || {}
+  var forceBuild = options.force || false
 
   // do the building
   Metalsmith(config.lessonRoot)
@@ -86,10 +85,10 @@ module.exports = function build(callback, options){
   // create collections
   .use(collections(collectionOptions))
   .use(changed({
-      force: forceBuild,
-      extnames: {
-          '.md': '.html'
-      }
+    force: forceBuild,
+    extnames: {
+      '.md': '.html'
+    }
   }))
   // convert markdown to html
   .use(md)
@@ -99,11 +98,11 @@ module.exports = function build(callback, options){
   .use(define(defineOptions))
   // apply layouts
   .use(layouts(layoutOptions))
-  //build
+  // build
   .destination('build')
-  .build(function(err){
-    if (err) console.log(err);
+  .build(function (err) {
+    if (err) console.log(err)
     // callback when build is done
-    callback(err);
-  });
-};
+    callback(err)
+  })
+}

--- a/check-links.js
+++ b/check-links.js
@@ -1,16 +1,16 @@
-var Static = require('node-static');
-var http = require('http');
-var Spider = require('node-spider');
-var assert = require('assert');
-var config = require('./config.js');
-var _ = require('lodash');
+var Static = require('node-static')
+var http = require('http')
+var Spider = require('node-spider')
+var assert = require('assert')
+var config = require('./config.js')
+var _ = require('lodash')
 
-function length(obj) {
-  var size = 0, key;
-  for (key in obj) {
-    if (obj.hasOwnProperty(key)) size++;
+function length (obj) {
+  var size = 0
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) size++
   }
-  return size;
+  return size
 }
 
 /**
@@ -21,7 +21,7 @@ function length(obj) {
  * @param {string} start URL where crawler should start looking for links.
  * @return {function} checkLinks Calling checkLinks will start crawling.
  */
-module.exports = function(start) {
+module.exports = function (start) {
   /**
   * checkLinks crawls all pages and check that href and src attributes does
   * have a HTTP 200 response. It checks links outside the start domain, but
@@ -29,30 +29,29 @@ module.exports = function(start) {
   *
   * @param {function} cb Called when all links have been checked.
   */
-  return function checkLinks(cb){
-    console.log('Checking all links found at ' + start);
-    var webserver;
+  return function checkLinks (cb) {
+    console.log('Checking all links found at ' + start)
+    var webserver
 
     if (start.search('http://localhost') === 0) {
       // we need to start a web server
-      var files = new Static.Server(config.buildRoot);
+      var files = new Static.Server(config.buildRoot)
       webserver = http.createServer(function (request, response) {
         request.addListener('end', function () {
-          files.serve(request, response);
-        }).resume();
-      });
-      webserver.listen(3000, crawl);
+          files.serve(request, response)
+        }).resume()
+      })
+      webserver.listen(3000, crawl)
     } else {
-      crawl();
+      crawl()
     }
-    function crawl(){
-      var resources = {};  // dict of referrers {link: [referrer1, referrer2, ..], link2..}
-      resources[start] = ['start'];
-      var failed = [];  // list of failed links
-      var retries = [];
-      var ok = 0;  // number of OK links
-      var broken = 0;  // number of broken links
-
+    function crawl () {
+      var resources = {}  // dict of referrers {link: [referrer1, referrer2, ..], link2..}
+      resources[start] = ['start']
+      var failed = []  // list of failed links
+      var retries = []
+      var ok = 0  // number of OK links
+      var broken = 0  // number of broken links
 
       var opts = {
         concurrent: 5,
@@ -60,156 +59,153 @@ module.exports = function(start) {
         error: error,
         headers: { 'user-agent': 'codeclub_lesson_builder' },
         timeout: 5000
-      };  // spider options
+      }  // spider options
 
       // text spider for HTML, CSS, etc
-      var textSpider = new Spider(opts);
+      var textSpider = new Spider(opts)
 
       // HEAD requests on external sites and binary files
-      var headOpts = _.assign({}, opts);
-      headOpts.method = 'HEAD';
-      var headSpider = new Spider(headOpts);
+      var headOpts = _.assign({}, opts)
+      headOpts.method = 'HEAD'
+      var headSpider = new Spider(headOpts)
 
       // let's go! :-)
-      textSpider.queue(start, parseResponse);
+      textSpider.queue(start, parseResponse)
 
       /**
        * on OK link
        */
-      function parseResponse(doc){
+      function parseResponse (doc) {
         // check status code
-        var code = doc.res.statusCode;
+        var code = doc.res.statusCode
         if (code !== 200 && this.opts.method === 'HEAD') {
           // try again with GET-method
-          textSpider.queue(this.opts.url, parseResponse);
-          return;
+          textSpider.queue(this.opts.url, parseResponse)
+          return
         }
         if (code !== 200) {
-          process.stdout.write('x'); // give some feedback
-          broken += 1;
-          failed.push({u:doc.url, c:code});
-          return;
+          process.stdout.write('x') // give some feedback
+          broken += 1
+          failed.push({u: doc.url, c: code})
+          return
         } else {
-          ok += 1;
-          process.stdout.write('.'); // give some feedback
+          ok += 1
+          process.stdout.write('.') // give some feedback
         }
 
         // do not parse binary files
         if (!/text|css|json|xml/i.test(doc.res.headers['content-type'])) {
-          return;
+          return
         }
 
         // only crawl links below start (not other domains)
         if (doc.url.search(start) === 0) {
-
           // all elements with href set
-          doc.$('*[href]').each(queueUrl('href'));
+          doc.$('*[href]').each(queueUrl('href'))
 
           // all elements with src set
-          doc.$('*[src]').each(queueUrl('src'));
+          doc.$('*[src]').each(queueUrl('src'))
         }
 
         /**
          * queueUrl closure
          */
-        function queueUrl(type){
-          return function(){
-            var href = doc.$(this).attr(type);
+        function queueUrl (type) {
+          return function () {
+            var href = doc.$(this).attr(type)
             // do not add mailto and javascript links
             if (href.search(/^(mailto|javascript)/) === 0) {
-              return;
+              return
             }
             // do not add github new issue links
             if (href.search(/^https:\/\/github.com\/.*?\/issues\/new/) === 0) {
-              return;
+              return
             }
             // do not check #-link explicit
-            var url = doc.resolve(href).split('#')[0];
+            var url = doc.resolve(href).split('#')[0]
             // already added
             if (url in resources) {
               // add referrer
-              resources[url].push(doc.url);
-              return;
+              resources[url].push(doc.url)
+              return
             }
-            queue(url);
+            queue(url)
             // store referrer
-            resources[url] = [doc.url];
+            resources[url] = [doc.url]
           }
         }
       }
 
-      function queue(url) {
+      function queue (url) {
         // remove earlier entries
         if (textSpider.visited[url]) {
-          textSpider.visited[url] = false;
+          textSpider.visited[url] = false
         }
         if (headSpider.visited[url]) {
-          headSpider.visited[url] = false;
+          headSpider.visited[url] = false
         }
         // external sites or binaries
-        if (url.search(start) !==0 ||
+        if (url.search(start) !== 0 ||
             url.search(/\.(jpg|png|gif|zip)$/) === 0) {
-          headSpider.queue(url, parseResponse);
+          headSpider.queue(url, parseResponse)
         } else {  // text, e.g., HTML, CSS, etc
-          textSpider.queue(url, parseResponse);
+          textSpider.queue(url, parseResponse)
         }
       }
-
 
       /**
        * on broken link
        */
-      function error(err, url) {
+      function error (err, url) {
         if (err.code === 'ETIMEDOUT' && retries.indexOf(url) === -1) {
           // retry timeouts once
-          process.stdout.write('r');
-          retries.push(url);
-          queue(url);
+          process.stdout.write('r')
+          retries.push(url)
+          queue(url)
         } else {
-          process.stdout.write('t'); // give some feedback
-          broken += 1;
-          failed.push({u:url, c:err.code});
+          process.stdout.write('t') // give some feedback
+          broken += 1
+          failed.push({u: url, c: err.code})
         }
       }
 
       /**
        * print results and exit
        */
-      function done() {
+      function done () {
         // wait until both spiders are done
         if (textSpider.active.length !== 0 || headSpider.active.length !== 0) {
-          var d = textSpider.active.length ? 'head done' : 'text done';
-          return;
+          return
         }
 
-        console.log('\nLink check done');
-        console.log('---------------');
-        console.log('Links OK:', ok);
-        console.log('Links broken:', broken);
-        console.log('---------------');
+        console.log('\nLink check done')
+        console.log('---------------')
+        console.log('Links OK:', ok)
+        console.log('Links broken:', broken)
+        console.log('---------------')
 
-        failed.forEach(function(fail){
-          console.log('Code', fail.c, 'for', fail.u, 'in');
-          resources[fail.u].forEach(function(ref){
-            console.log(' -', ref);
-          });
-        });
+        failed.forEach(function (fail) {
+          console.log('Code', fail.c, 'for', fail.u, 'in')
+          resources[fail.u].forEach(function (ref) {
+            console.log(' -', ref)
+          })
+        })
 
-        assert.equal(ok+broken, length(resources));
+        assert.equal(ok + broken, length(resources))
 
         if (webserver) {
-          webserver.close();
+          webserver.close()
         }
 
         if (broken !== 0) {
           // avoid error trace
-          process.exit(1);
+          process.exit(1)
         } else {
-          cb();
+          cb()
           // make sure we exit when node has timed out sockets hanging
-          process.exit(0);
+          process.exit(0)
         }
       }
     } // crawl end
-  };
-};
+  }
+}

--- a/config.js
+++ b/config.js
@@ -1,23 +1,22 @@
 /*
  * # DEPENDENCIES #
  */
-var path = require('path');
-var globby = require('globby');
+var path = require('path')
+var globby = require('globby')
 
 /*
  * Variables that depend on each other
  */
 
 // paths
-var lessonRoot = path.resolve('..');
-var buildRoot = path.join(lessonRoot, 'build');
-var builderRoot = path.basename(__dirname);
-var assetRoot = path.join(buildRoot, 'assets');
-var sourceFolder = 'src';
-var sourceRoot = path.join(lessonRoot, sourceFolder);
-var i18nRoot = path.join(__dirname, 'assets', 'locales');
-var i18nDest = path.join(buildRoot, 'locales');
-
+var lessonRoot = path.resolve('..')
+var buildRoot = path.join(lessonRoot, 'build')
+var builderRoot = path.basename(__dirname)
+var assetRoot = path.join(buildRoot, 'assets')
+var sourceFolder = 'src'
+var sourceRoot = path.join(lessonRoot, sourceFolder)
+var i18nRoot = path.join(__dirname, 'assets', 'locales')
+var i18nDest = path.join(buildRoot, 'locales')
 
 /**
  * Collections
@@ -25,45 +24,44 @@ var i18nDest = path.join(buildRoot, 'locales');
  * This allows for redirections, e.g., empty index.html with
  * <script> window.location = "newUrl" </script>
  */
-var collectionIndexPath = sourceRoot + '/*/index.md';
-var collectionIndexes = globby.sync(collectionIndexPath);
-var collections = collectionIndexes.map(function(value){
+var collectionIndexPath = sourceRoot + '/*/index.md'
+var collectionIndexes = globby.sync(collectionIndexPath)
+var collections = collectionIndexes.map(function (value) {
   // ["../src/python/index.md", ...] -> ["python", ...]
-  var start = sourceRoot.length + 1;
-  var length = value.indexOf('/index.md') - start;
-  return value.substr(start, length);
-});
-
+  var start = sourceRoot.length + 1
+  var length = value.indexOf('/index.md') - start
+  return value.substr(start, length)
+})
 
 /*
  * Export. Independent variables can be put here directly.
  */
 var config = {
-  assetRoot:      assetRoot,
-  buildRoot:      buildRoot,
-  builderRoot:    builderRoot,
-  i18nRoot:       i18nRoot,
-  i18nDest:       i18nDest,
-  lessonRoot:     lessonRoot,
+  assetRoot: assetRoot,
+  buildRoot: buildRoot,
+  builderRoot: builderRoot,
+  i18nRoot: i18nRoot,
+  i18nDest: i18nDest,
+  lessonRoot: lessonRoot,
   // folder names
   playlistFolder: 'playlists',
-  sourceFolder:   sourceFolder,
-  sourceRoot:     sourceRoot,
+  sourceFolder: sourceFolder,
+  sourceRoot: sourceRoot,
   // collections
-  collections:    collections,
+  collections: collections,
   // github webhook for automatic building
   // Payload URL will be http://ghHost:ghPort/ghPath
-  ghHost:         '0.0.0.0', // 0.0.0.0 listen on all interfaces
-  ghPort:         3034,
-  ghPath:         '/',
-  ghMergeCommand:  '../deploy.sh',
-  ghSecret:       'secret',
+  ghHost: '0.0.0.0', // 0.0.0.0 listen on all interfaces
+  ghPort: 3034,
+  ghPath: '/',
+  ghMergeCommand: '../deploy.sh',
+  ghSecret: 'secret',
   // link crawling
   productionCrawlStart: 'http://kodeklubben.github.io/',
   showFlags: false,
   locales: ['nb-NO', 'en-US'],
   // for improve links in lessons
   repo: 'https://github.com/kodeklubben/oppgaver'
-};
+}
 
-module.exports = config;
+module.exports = config

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,43 +1,41 @@
 /**
  * # DEPENDENCIES #
  */
-var gulp = require('gulp');
+var gulp = require('gulp')
 try {
-  var browserSync = require('browser-sync');
-  var reload = browserSync.reload; // reload shorthand
-} catch(e) { }
-var path = require('path');
-var addsrc = require('gulp-add-src');
-var del = require('del');
-var run = require('run-sequence');
-var merge = require('merge-stream');
-var _ = require('lodash');
+  var browserSync = require('browser-sync')
+  var reload = browserSync.reload // reload shorthand
+} catch (e) { }
+var path = require('path')
+var addsrc = require('gulp-add-src')
+var del = require('del')
+var run = require('run-sequence')
+var _ = require('lodash')
 // metalsmith building
-var build = require('./build.js');
-var buildIndexes = require('./build-indexes.js');
-var buildSearchIndex = require('./build-search-index.js');
+var build = require('./build.js')
+var buildIndexes = require('./build-indexes.js')
+var buildSearchIndex = require('./build-search-index.js')
 // styles and scripts
-var less = require('gulp-less');
-var concat = require('gulp-concat');
-var autoprefixer = require('gulp-autoprefixer');
-var minify = require('gulp-minify-css');
-var uglify = require('gulp-uglify');
-var browserify = require('browserify');
-var watchify = require('watchify');
-var source = require('vinyl-source-stream');
-var sourcemaps = require('gulp-sourcemaps');
-var buffer = require('vinyl-buffer');
+var less = require('gulp-less')
+var concat = require('gulp-concat')
+var autoprefixer = require('gulp-autoprefixer')
+var minify = require('gulp-minify-css')
+var uglify = require('gulp-uglify')
+var browserify = require('browserify')
+var watchify = require('watchify')
+var source = require('vinyl-source-stream')
+var sourcemaps = require('gulp-sourcemaps')
+var buffer = require('vinyl-buffer')
 // pdf generation
-var pdf = require('./pdf.js');
+var pdf = require('./pdf.js')
 // link-checking
-var checkLinks = require('./check-links');
+var checkLinks = require('./check-links')
 // get configuration variables
-var config = require('./config.js');
+var config = require('./config.js')
 
 // github hooks
-var exec = require('child_process').exec;
-var githubhook = require('githubhook');
-
+var exec = require('child_process').exec
+var githubhook = require('githubhook')
 
 /**
  * # TASKS #
@@ -50,13 +48,13 @@ gulp.task('server', ['build', 'build-indexes', 'css', 'js:client', 'js:vendor', 
   browserSync.init({
     server: { baseDir: config.buildRoot },
     ghostMode: false
-  });
-});
+  })
+})
 
 /**
  * build less files to css, prefix and minify
  */
-gulp.task('css', function(cb) {
+gulp.task('css', function (cb) {
   return gulp.src('styles/main.less')
     .pipe(less())
     .on('error', cb)
@@ -68,20 +66,19 @@ gulp.task('css', function(cb) {
     .pipe(autoprefixer())
     .pipe(minify())
     .pipe(concat('style.min.css'))
-    .pipe(gulp.dest(config.assetRoot));
-});
+    .pipe(gulp.dest(config.assetRoot))
+})
 
 /**
  * copy all assets to build directory
  */
-gulp.task('assets', function(){
+gulp.task('assets', function () {
   return gulp.src([
-      'assets/**/*',
-      'node_modules/scratchblocks2/build/*/*.png',
-      'node_modules/bootstrap/dist/*/glyphicons-halflings-regular.*'
-    ])
-    .pipe(gulp.dest(config.assetRoot));
-});
+    'assets/**/*',
+    'node_modules/scratchblocks2/build/*/*.png',
+    'node_modules/bootstrap/dist/*/glyphicons-halflings-regular.*'
+  ]).pipe(gulp.dest(config.assetRoot))
+})
 
 /**
  * browserify and uglify client-side scripts
@@ -92,38 +89,38 @@ var b = browserify({
   packageCache: {},
   plugin: [watchify],
   debug: true
-}).transform('babelify', { presets: ["es2015"] });
-b.on('log', console.log);
+}).transform('babelify', { presets: ['es2015'] })
+b.on('log', console.log)
 
 gulp.task('js:client', function () {
   // do not uglify in dev env
   return b.bundle()
     .on('error', (err) => {
-      console.log(err);
-      this.emit('end');
+      console.log(err)
+      this.emit('end')
     })
     .pipe(source('script.min.js'))
-    .pipe(gulp.dest(config.assetRoot));
-});
+    .pipe(gulp.dest(config.assetRoot))
+})
 
 gulp.task('js:dist', function () {
   return b.bundle()
     .on('error', (err) => {
-      console.log(err);
-      this.emit('end');
+      console.log(err)
+      this.emit('end')
     })
     .pipe(source('script.min.js'))
     .pipe(buffer())
     .pipe(sourcemaps.init({ loadMaps: true }))
     .pipe(uglify())
     .pipe(sourcemaps.write('./'))
-    .pipe(gulp.dest(config.assetRoot));
-});
+    .pipe(gulp.dest(config.assetRoot))
+})
 
 /**
  * concat and uglify vendor scripts
  */
-gulp.task('js:vendor', function(){
+gulp.task('js:vendor', function () {
   return gulp.src([
     'node_modules/scratchblocks2/build/scratchblocks2.js',
     'node_modules/scratchblocks2/src/translations.js',
@@ -136,20 +133,20 @@ gulp.task('js:vendor', function(){
     'node_modules/jquery/dist/jquery.min.js'
   ]))
   .pipe(concat('vendor.min.js'))
-  .pipe(gulp.dest(config.assetRoot));
-});
+  .pipe(gulp.dest(config.assetRoot))
+})
 
 /**
  * metalsmith building
  */
-gulp.task('build', build);
-gulp.task('build-indexes', buildIndexes);
-gulp.task('build-search-index', buildSearchIndex);
+gulp.task('build', build)
+gulp.task('build-indexes', buildIndexes)
+gulp.task('build-search-index', buildSearchIndex)
 
 /**
  * dist - build all without serving
  */
-gulp.task('dist', function(cb){
+gulp.task('dist', function (cb) {
   // preferred way to this will change in gulp 4
   // see https://github.com/gulpjs/gulp/issues/96
   run('clean',
@@ -157,69 +154,67 @@ gulp.task('dist', function(cb){
       'pdf',
       function (err) {
         // make sure process exit (b = watchify bundle)
-        b.close();
-        cb(err);
-      });
-});
+        b.close()
+        cb(err)
+      })
+})
 
 /**
  * clean - remove files in build directory
  */
-gulp.task('clean', function(cb){
-  del([path.join(config.lessonRoot, 'build')], {force: true}, cb);
-});
+gulp.task('clean', function (cb) {
+  del([path.join(config.lessonRoot, 'build')], {force: true}, cb)
+})
 
 /**
  * pdf - generate pdfs of all htmls
  */
-gulp.task('pdf', pdf);
+gulp.task('pdf', pdf)
 
 /**
  * links - check for broken links
  */
-gulp.task('links', checkLinks('http://localhost:3000/'));
-gulp.task('prodlinks', checkLinks(config.productionCrawlStart));
+gulp.task('links', checkLinks('http://localhost:3000/'))
+gulp.task('prodlinks', checkLinks(config.productionCrawlStart))
 
 /**
  * github webhook for automatic building
  */
-gulp.task('github', function(cb){
+gulp.task('github', function (cb) {
   var github = githubhook({
     host: config.ghHost,
     port: config.ghPort,
     path: config.ghPath,
     secret: config.ghSecret
-  });
-  github.on('*', function(event){
+  })
+  github.on('*', function (event) {
     if (event !== 'pull_request') {
-      console.log('Webhook event "' + event + '". Nothing to do.');
+      console.log('Webhook event "' + event + '". Nothing to do.')
     }
-  });
-  github.on('pull_request', build);
-  github.listen();
-  var currentlyBuilding = false;
-  function build(repo, ref, data) {
+  })
+  github.on('pull_request', build)
+  github.listen()
+  var currentlyBuilding = false
+  function build (repo, ref, data) {
     if (currentlyBuilding) {
-      console.log('Already building. Waiting 4 minutes...');
-      _.delay(build, 4*60*1000, repo, ref, data);
-    }
-    else if (data.pull_request.merged) {
-      currentlyBuilding = true;
-      console.log('Merged PR, building...');
-      deployProc = exec(config.ghMergeCommand, function(err, stdout, stderr) {
-        if(err!==null) {
-          console.log(stderr);
+      console.log('Already building. Waiting 4 minutes...')
+      _.delay(build, 4 * 60 * 1000, repo, ref, data)
+    } else if (data.pull_request.merged) {
+      currentlyBuilding = true
+      console.log('Merged PR, building...')
+      exec(config.ghMergeCommand, function (err, stdout, stderr) {
+        if (err !== null) {
+          console.log(stderr)
         } else {
-          console.log('Build successfull.');
+          console.log('Build successfull.')
         }
-        currentlyBuilding = false;
-      });
+        currentlyBuilding = false
+      })
     } else {
-      console.log('Webhook event "pull_request", not merged. Nothing to do.');
+      console.log('Webhook event "pull_request", not merged. Nothing to do.')
     }
   }
-});
-
+})
 
 /**
  * # DEFAULT TASK #
@@ -230,20 +225,20 @@ gulp.task('github', function(cb){
  * serve build directory with livereload
  * watch files -> build and reload upon changes
  */
-gulp.task('default', ['server'], function(){
+gulp.task('default', ['server'], function () {
   /**
    * ## WATCHES ##
    */
   // files which are built with metalsmith
-  gulp.watch([config.sourceRoot + '/**', '!' + config.sourceRoot + '/**/index.md'], ['build', reload]);
-  gulp.watch([__dirname + '/layouts/**', config.sourceRoot + '/**/index.md'], ['build-indexes', reload]);
+  gulp.watch([config.sourceRoot + '/**', '!' + config.sourceRoot + '/**/index.md'], ['build', reload])
+  gulp.watch([__dirname + '/layouts/**', config.sourceRoot + '/**/index.md'], ['build-indexes', reload])
 
   // styles
-  gulp.watch(path.join(__dirname, 'styles', '**', '*'), ['css', reload]);
+  gulp.watch(path.join(__dirname, 'styles', '**', '*'), ['css', reload])
 
   // scripts
-  gulp.watch(path.join(__dirname, 'scripts', '**'), ['js:client', reload]);
+  gulp.watch(path.join(__dirname, 'scripts', '**'), ['js:client', reload])
 
   // assets
-  gulp.watch(path.join(__dirname, 'assets', '**'), ['assets', reload]);
-});
+  gulp.watch(path.join(__dirname, 'assets', '**'), ['assets', reload])
+})

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -7,6 +7,7 @@ try {
   var reload = browserSync.reload // reload shorthand
 } catch (e) { }
 var path = require('path')
+var join = path.join  // shorthand
 var addsrc = require('gulp-add-src')
 var del = require('del')
 var run = require('run-sequence')
@@ -163,7 +164,7 @@ gulp.task('dist', function (cb) {
  * clean - remove files in build directory
  */
 gulp.task('clean', function (cb) {
-  del([path.join(config.lessonRoot, 'build')], {force: true}, cb)
+  del([join(config.lessonRoot, 'build')], {force: true}, cb)
 })
 
 /**
@@ -230,15 +231,15 @@ gulp.task('default', ['server'], function () {
    * ## WATCHES ##
    */
   // files which are built with metalsmith
-  gulp.watch([config.sourceRoot + '/**', '!' + config.sourceRoot + '/**/index.md'], ['build', reload])
-  gulp.watch([__dirname + '/layouts/**', config.sourceRoot + '/**/index.md'], ['build-indexes', reload])
+  gulp.watch([join(config.sourceRoot, '/**'), '!' + config.sourceRoot + '/**/index.md'], ['build', reload])
+  gulp.watch([join(__dirname, '/layouts/**'), config.sourceRoot + '/**/index.md'], ['build-indexes', reload])
 
   // styles
-  gulp.watch(path.join(__dirname, 'styles', '**', '*'), ['css', reload])
+  gulp.watch(join(__dirname, 'styles', '**', '*'), ['css', reload])
 
   // scripts
-  gulp.watch(path.join(__dirname, 'scripts', '**'), ['js:client', reload])
+  gulp.watch(join(__dirname, 'scripts', '**'), ['js:client', reload])
 
   // assets
-  gulp.watch(path.join(__dirname, 'assets', '**'), ['assets', reload])
+  gulp.watch(join(__dirname, 'assets', '**'), ['assets', reload])
 })

--- a/i18n.js
+++ b/i18n.js
@@ -1,8 +1,7 @@
-var i18n = require('i18next');
-var backend = require('i18next-sync-fs-backend');
-var config = require('./config.js');
-var join = require('path').join;
-
+var i18n = require('i18next')
+var backend = require('i18next-sync-fs-backend')
+var config = require('./config.js')
+var join = require('path').join
 
 i18n
   .use(backend)
@@ -15,18 +14,18 @@ i18n
     backend: {
       loadPath: join(config.i18nRoot, '{{lng}}/{{ns}}.json5')
     }
-  }, function(err) {
+  }, function (err) {
     if (err) {
-      console.log(err);
+      console.log(err)
       throw new Error('i18next failed to initialize')
     }
-  });
+  })
 
 /**
  * Export the translate function.
  *
  * Usage:
- *    var translate = require('./i18n.js');
- *    translate('key');
+ *    var translate = require('./i18n.js')
+ *    translate('key')
  */
-module.exports = i18n.getFixedT(config.locales[0]);
+module.exports = i18n.getFixedT(config.locales[0])

--- a/lesson-readme.js
+++ b/lesson-readme.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const config = require('./config.js')
 
 /**
  * Metalsmith plugin.
@@ -19,8 +18,6 @@ module.exports = function (opts) {
       }
       let readme = path.join(path.dirname(file), opts.readme)
       if (readme in files) {
-        let link =  [config.repo, 'tree', 'master',
-                     config.sourceFolder, readme].join('/')
         files[file].readme = readme.replace(/\.md$/, '.html')
       }
     }

--- a/lesson-readme.js
+++ b/lesson-readme.js
@@ -36,7 +36,7 @@ function getFirstLesson (file, files) {
   // (?!not this).+ match anything expect "not this"
   names[names.length - 1] = `(?!${basename}).+\\.md$`
   const re = new RegExp('^' + names.join('\\' + path.sep))
-  const m = Object.keys(files).filter(file => file.search(re) === 0)
+  const m = Object.keys(files).filter((file) => file.search(re) === 0)
   if (m[0]) {
     return m[0].replace(/\.md$/, '.html')
   }

--- a/markdown.js
+++ b/markdown.js
@@ -1,38 +1,38 @@
-var markdownit = require('metalsmith-markdownit');
-var anchor = require('markdown-it-anchor');
-var attrs = require('markdown-it-attrs');
-var headerSections = require('markdown-it-header-sections');
-var implicitFigures = require('markdown-it-implicit-figures');
-var hljs = require('highlight.js');
+var markdownit = require('metalsmith-markdownit')
+var anchor = require('markdown-it-anchor')
+var attrs = require('markdown-it-attrs')
+var headerSections = require('markdown-it-header-sections')
+var implicitFigures = require('markdown-it-implicit-figures')
+var hljs = require('highlight.js')
 
 // setup markdown parser
 var md = markdownit({
   html: true,  // allow html in source
   linkify: true,  // parse URL-like text to links
   langPrefix: '',  // no prefix in class for code blocks
-  highlight: function(str, lang) {
+  highlight: function (str, lang) {
     if (lang && hljs.getLanguage(lang)) {
       // highlight supported languages
       try {
-        return hljs.highlight(lang, str).value;
-      } catch(e) {}
+        return hljs.highlight(lang, str).value
+      } catch (e) {}
     }
     if (!lang) {
       // autodetect language
       try {
-        return hljs.highlightAuto(str).value;
-      } catch(e) {}
+        return hljs.highlightAuto(str).value
+      } catch (e) {}
     }
     // do not highlight unsupported or undetected
-    return '';
+    return ''
   }
-});
+})
 
 md.parser
   .use(attrs)
   .use(headerSections)
   .use(implicitFigures)
   .use(anchor)
-  .linkify.tlds('.py', false);  // linkify: turn of .py top level domain;
+  .linkify.tlds('.py', false)  // linkify: turn of .py top level domain
 
-module.exports = md;
+module.exports = md

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "node-static": "^0.7.7",
     "nodepdf-series": "^0.2.2",
     "run-sequence": "^1.0.2",
+    "standard": "^6.0.7",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0",
@@ -72,6 +73,7 @@
   },
   "scripts": {
     "install": "napa",
+    "lint": "standard",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "forever node_modules/gulp/bin/gulp.js"
   },

--- a/pdf.js
+++ b/pdf.js
@@ -1,45 +1,45 @@
-var glob = require('globby');
-var path = require('path');
-var each = require('async-each');
-var _    = require('lodash');
-var PDF  = require('nodepdf-series');
-var config = require('./config.js');
+var glob = require('globby')
+var path = require('path')
+var each = require('async-each')
+var _ = require('lodash')
+var PDF = require('nodepdf-series')
+var config = require('./config.js')
 
-var concurrent = 4; // how many processes to spawn
-var pdfOptions = { 'viewportSize': { 'width': 1024 } };
+var concurrent = 4 // how many processes to spawn
+var pdfOptions = { 'viewportSize': { 'width': 1024 } }
 
 var pattern = [config.buildRoot + '/**/*.html',
                '!' + config.buildRoot + '/index.html',
-               '!' + config.buildRoot + '/*/index.html'];
+               '!' + config.buildRoot + '/*/index.html']
 
-function generatePdf(done){
-  var files = glob.sync(pattern);
-  files = files.map(function(file){
-    return 'file://' + path.resolve(file);
-  });
-  var chunkSize = Math.round(files.length/concurrent);
-  var chunks = _.chunk(files, chunkSize);
-  each(chunks, function(chunk, cb){
-    PDF.render(chunk, pdfOptions, function(err){
-      cb(err);
-    });
-  }, function(err){
+function generatePdf (done) {
+  var files = glob.sync(pattern)
+  files = files.map(function (file) {
+    return 'file://' + path.resolve(file)
+  })
+  var chunkSize = Math.round(files.length / concurrent)
+  var chunks = _.chunk(files, chunkSize)
+  each(chunks, function (chunk, cb) {
+    PDF.render(chunk, pdfOptions, function (err) {
+      cb(err)
+    })
+  }, function (err) {
     // check if all htmls are converted
-    var pdfs = glob.sync(config.buildRoot + '/**/*.pdf');
-    pdfs = pdfs.map(function(pdf){
-      return path.resolve(pdf);
-    });
-    var diff = files.map(function(file){
-      file = file.replace('file://', '').replace('.html', '.pdf');
-      if (pdfs.indexOf(file) == -1) return file;
-    });
-    diff = _.compact(diff); // remove falsey values
+    var pdfs = glob.sync(config.buildRoot + '/**/*.pdf')
+    pdfs = pdfs.map(function (pdf) {
+      return path.resolve(pdf)
+    })
+    var diff = files.map(function (file) {
+      file = file.replace('file://', '').replace('.html', '.pdf')
+      if (pdfs.indexOf(file) === -1) return file
+    })
+    diff = _.compact(diff) // remove falsey values
     if (diff.length !== 0) {
       var lengthErr = new Error('Not all htmls was converted to pdf. ' +
-                                'Missing pdfs:\n' + diff.join('\n'));
+                                'Missing pdfs:\n' + diff.join('\n'))
     }
-    done(err || lengthErr);
-  });
-};
+    done(err || lengthErr)
+  })
+}
 
-module.exports = generatePdf;
+module.exports = generatePdf

--- a/playlists.js
+++ b/playlists.js
@@ -40,7 +40,7 @@ module.exports = function (opts) {
           const key = path.normalize(path.join(collection, ...file.split('/')))
           if (!files[key]) {
             console.warn('playlist: file not found')
-            console.warn(key +' in '+ file)
+            console.warn(key + ' in ' + file)
           }
           return files[key]
         })
@@ -56,9 +56,11 @@ function playlistName (filename) {
   return path.basename(filename).replace('.txt', '').replace(/_/g, ' ')
 }
 
+/**
+ * replace chars in playlist-name, so that it can be used as id or class
+ */
 function playlistId (name) {
-  // replace chars in playlist-name, so that it can be used as id or class
-  var id = name.replace(/ /g, '_');
-  id = id.replace(/[\,\.\-\?]/g, '');
-  return id;
+  var id = name.replace(/ /g, '_')
+  id = id.replace(/[\,\.\-\?]/g, '')
+  return id
 }

--- a/playlists.js
+++ b/playlists.js
@@ -18,12 +18,12 @@ module.exports = function (opts) {
     metadata.playlists = {}
 
     // for each collection
-    opts.collections.map(collection => {
+    opts.collections.map((collection) => {
       // /course\/playlists\/[^\/]+txt$/
       const re = new RegExp([collection, config.playlistFolder,
                             '[^', ']+txt$'].join('\\' + path.sep))
       // [ course/playlists/learn_python.txt, ...]
-      const playlists = Object.keys(files).filter(file => {
+      const playlists = Object.keys(files).filter((file) => {
         return file.search(re) === 0
       })
 
@@ -36,7 +36,7 @@ module.exports = function (opts) {
 
         let lessons = files[file].contents.toString('utf8')
         lessons = lessons.match(/[^\r\n]+/g)  // read lines
-        playlist.lessons = lessons.map(file => {
+        playlist.lessons = lessons.map((file) => {
           const key = path.normalize(path.join(collection, ...file.split('/')))
           if (!files[key]) {
             console.warn('playlist: file not found')

--- a/scripts/course-hover.js
+++ b/scripts/course-hover.js
@@ -1,29 +1,29 @@
+/* eslint-env jquery */
+
 /**
  * show introduction to lesson on :hover
  */
 
-const SELECTOR = '.courses > a';
-const CONTAINER = '.courseIntro';
+const SELECTOR = '.courses > a'
+const CONTAINER = '.courseIntro'
 
-
-$(SELECTOR).hover(showIntro, hideIntro);
-
+$(SELECTOR).hover(showIntro, hideIntro)
 
 function showIntro () {
-  const elm = $(this);
-  const url = elm.attr('href');
+  const elm = $(this)
+  const url = elm.attr('href')
   if (!url) {
-    return;
+    return
   }
 
-  const container = $('<div />');
-  container.addClass(CONTAINER.replace('.', ''));
-  $('body').append(container);
+  const container = $('<div />')
+  container.addClass(CONTAINER.replace('.', ''))
+  $('body').append(container)
 
   $.ajax(url)
     .then(filterIntro)
     .then(filterContent(elm))
-    .then(createPopover(elm));
+    .then(createPopover(elm))
 }
 
 /**
@@ -31,11 +31,11 @@ function showIntro () {
  */
 function filterIntro (data) {
   // ? is ungreedy match
-  var m = data.match(/class="content"[\s\S]+?<\/div>/g);
+  var m = data.match(/class="content"[\s\S]+?<\/div>/g)
   if (!m) {
-    return '';
+    return ''
   }
-  return '<div '+ m[0];
+  return '<div ' + m[0]
 }
 
 /**
@@ -43,34 +43,34 @@ function filterIntro (data) {
  */
 function filterContent (elm) {
   return function (data) {
-    const intro = {};
-    intro.text = $(data).find('> p');
+    const intro = {}
+    intro.text = $(data).find('> p')
     if (intro.text.length === 0) {
-      return;
+      return
     }
-    intro.lessons = elm.find('.lessons');
-    return intro;
+    intro.lessons = elm.find('.lessons')
+    return intro
   }
 }
 
 /**
  * functional Intro element
  */
-function Intro(data) {
-  const elm = $('<div />');
-  elm.append(data.text);
-  elm.append(data.lessons);
-  return elm;
+function Intro (data) {
+  const elm = $('<div />')
+  elm.append(data.text)
+  elm.append(data.lessons)
+  return elm
 }
 
 /**
  * opens a popover with the intro
  */
-let timeout;
+let timeout
 function createPopover (elm) {
   return function (data) {
     if (!data) {
-      return;
+      return
     }
     elm.popover({
       animate: true,
@@ -79,10 +79,10 @@ function createPopover (elm) {
       trigger: 'manual',
       html: true,
       content: Intro(data)
-    });
+    })
     // debounce
-    clearTimeout(timeout);
-    timeout = setTimeout(() => elm.popover('show'), 200);
+    clearTimeout(timeout)
+    timeout = setTimeout(() => elm.popover('show'), 200)
   }
 }
 
@@ -90,6 +90,6 @@ function createPopover (elm) {
  * remove all intro popovers
  */
 function hideIntro () {
-  clearTimeout(timeout);
-  $(CONTAINER).remove();
+  clearTimeout(timeout)
+  $(CONTAINER).remove()
 }

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -1,8 +1,9 @@
-import i18n from 'i18next';
-import XHR from 'i18next-xhr-backend';
-import lngDetector from 'i18next-browser-languagedetector';
-import JSON5 from 'json5';
-
+/* eslint-env jquery */
+/* global relative */
+import i18n from 'i18next'
+import XHR from 'i18next-xhr-backend'
+import lngDetector from 'i18next-browser-languagedetector'
+import JSON5 from 'json5'
 
 /**
  * Export the instance of i18n.
@@ -11,7 +12,7 @@ import JSON5 from 'json5';
  *    import i18n from './i18n.js'
  *    i18n.on('initialized languageChanged', () => {
         // called upon initialization and changeLanguage
- *      i18n.t('key');  // returns the translation
+ *      i18n.t('key')  // returns the translation
  *    })
  */
 export default i18n
@@ -19,7 +20,7 @@ export default i18n
 $(() => {
   // page loaded
   // FIXME: nb-NO default language?
-  const locales = ['nb-NO', 'en-US'];  // first is default language
+  const locales = ['nb-NO', 'en-US']  // first is default language
   i18n.use(XHR)
   .use(lngDetector)
   .init({
@@ -34,9 +35,8 @@ $(() => {
       parse: JSON5.parse
     }
   }, () => {
-    i18n.on('languageChanged', onLanguageChanged);
-  });
-
+    i18n.on('languageChanged', onLanguageChanged)
+  })
 
   /**
   * When i18n is initialized, or if the language is changed, translate all tags
@@ -44,31 +44,29 @@ $(() => {
   * E.g. a tag with:
   *   data-i18n="html=key" will set this tag's innerHTML to the caption given by "key".
   *   data-i18n="placeholder=key" will set the attribute "placeholder" to the caption given by "key".
-  *   data-i18n="html=key1;placeholder=key2" will set both innerHTML and the attribute "placeholder" to
+  *   data-i18n="html=key1placeholder=key2" will set both innerHTML and the attribute "placeholder" to
   *                                          the captions for "key1" and "key2", respectively.
   */
 
-  function onLanguageChanged() {
+  function onLanguageChanged () {
     $('[data-i18n]').each((_, item) => {
-      const captions = $(item).attr('data-i18n').split(';');
-      for (let i=0; i<captions.length; ++i) {
-        const capSplit = captions[i].split('=');
-        const key = capSplit[0];
-        const caption = i18n.t(capSplit[1]);
-        if (key=='html') {
-          //console.log("Setting innerHTML=" + caption);
-          $(item).html(caption);
-        }
-        else {
-          //console.log("Setting attribute " + key + ": " + caption);
-          $(item).attr(key, caption);
+      const captions = $(item).attr('data-i18n').split('')
+      for (let i = 0; i < captions.length; ++i) {
+        const capSplit = captions[i].split('=')
+        const key = capSplit[0]
+        const caption = i18n.t(capSplit[1])
+        if (key === 'html') {
+          // console.log("Setting innerHTML=" + caption)
+          $(item).html(caption)
+        } else {
+          // console.log("Setting attribute " + key + ": " + caption)
+          $(item).attr(key, caption)
         }
       }
-    });
-    $('[title]').tooltip('destroy').tooltip();  // reset tooltips
+    })
+    $('[title]').tooltip('destroy').tooltip()  // reset tooltips
   }
-});
-
+})
 
 /**
  * Called from html, e.g. clicking on flag
@@ -76,6 +74,6 @@ $(() => {
  */
 window.setLanguage = (locale) => {
   i18n.changeLanguage(locale, (err) => {
-    if (err) { console.log(err); }
-  });
-};
+    if (err) { console.log(err) }
+  })
+}

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,25 +1,25 @@
+/* eslint-env jquery */
 /**
  * Entry point for scripts.
  * Load after index.js so that click handles in index.js has priority.
  */
 
-import './search.js';
-import './intro.js';
-import playlistInit from './playlist.js';
-import './course-hover.js';
-import './lesson-hover.js';
-import i18n from './i18n.js';
+import './search.js'
+import './intro.js'
+import playlistInit from './playlist.js'
+import './course-hover.js'
+import './lesson-hover.js'
+import i18n from './i18n.js'
 
-let t;
+let t
 i18n.on('initialized', () => {
-  t = i18n.getFixedT();
+  t = i18n.getFixedT()
 
   /*
   * tooltips
   */
-  $('[title]').tooltip();
-});
-
+  $('[title]').tooltip()
+})
 
 $(() => {
   // page loaded
@@ -27,44 +27,43 @@ $(() => {
   /*
   * show/hide course info
   */
-  $('h1.info').click(function(){
-    $('.content').slideToggle();
-    $('.infoicon').toggleClass('glyphicon-minus-sign').toggleClass('glyphicon-plus-sign');
-    $('.clickformore').addClass('hide');
-  });
+  $('h1.info').click(function () {
+    $('.content').slideToggle()
+    $('.infoicon').toggleClass('glyphicon-minus-sign').toggleClass('glyphicon-plus-sign')
+    $('.clickformore').addClass('hide')
+  })
 
   /**
   * toggle hints
   */
-  $('toggle').click(function(){
-    $('hide', this).slideToggle();
-  });
+  $('toggle').click(function () {
+    $('hide', this).slideToggle()
+  })
 
   /**
   * show sections when correct answer is given
   */
-  $('input[for^="test-"]').keyup(function(event){
-    const answer = this.attributes.answer.value.toLowerCase();
-    const value = this.value.toLowerCase();
-    if (answer == value) {
-      const section = this.attributes.for.value;
-      $("section."+ section).slideDown();
+  $('input[for^="test-"]').keyup(function (event) {
+    const answer = this.attributes.answer.value.toLowerCase()
+    const value = this.value.toLowerCase()
+    if (answer === value) {
+      const section = this.attributes.for.value
+      $('section.' + section).slideDown()
     }
-  });
-
+  })
 
   /*
   * external resources, wait for translation function
   */
   $('.courses > a[href^="http"]')
-    .each(externalResourcePopover('indexjs.externalCourse', 'indexjs.continueToCourse'));
+    .each(externalResourcePopover('indexjs.externalCourse', 'indexjs.continueToCourse'))
   $('.playlist > a[href^="http"], .level > a[href^="http"]')
-    .each(externalResourcePopover('indexjs.externalLesson', 'indexjs.continueToLesson'));
+    .each(externalResourcePopover('indexjs.externalLesson', 'indexjs.continueToLesson'))
 
-  let openExternalPopover;  // global state
-  function externalResourcePopover(thisIs, continueTo) {
-    return function(_, elm){
-      function getContent() {
+  let openExternalPopover  // global state
+  function externalResourcePopover (thisIs, continueTo) {
+    return function (_, elm) {
+      function getContent () {
         let content = `<span><p data-i18n="html=${thisIs}">${t(thisIs)}</p>`
         content += `<a href="${elm.href}" data-i18n="html=${continueTo}">${t(continueTo)}</a></span>`
         return content
@@ -76,33 +75,32 @@ $(() => {
         html: 'true',
         title: () => t('indexjs.externalResource'),
         content: getContent
-      });
-      $(elm).click(function(event){
-        event.preventDefault();
-        event.stopPropagation();
+      })
+      $(elm).click(function (event) {
+        event.preventDefault()
+        event.stopPropagation()
         // if other popover is open, hide it
         if (openExternalPopover && openExternalPopover !== elm) {
-          $(openExternalPopover).popover('hide');
+          $(openExternalPopover).popover('hide')
         }
         // if already open, set openExternalPopover to false
         // else, keep track of open popover
-        openExternalPopover = (openExternalPopover === elm) ? false : elm;
-        $(elm).popover('toggle');
-      });
+        openExternalPopover = (openExternalPopover === elm) ? false : elm
+        $(elm).popover('toggle')
+      })
     }
   }
-
 
   /**
    * click teacher notes in lesson index
    * hack, as link inside link is not possible
    */
   $('.lesson > .readme').click(function (event) {
-    event.preventDefault();
-    event.stopPropagation();
-    var url = $(this).attr('href');
+    event.preventDefault()
+    event.stopPropagation()
+    var url = $(this).attr('href')
     if (url) {
-      window.location.href = url;
+      window.location.href = url
     }
   })
 
@@ -112,6 +110,5 @@ $(() => {
   * playlist click handlers are registered last to let other click handlers
   * do their thing (external popover, teacher notes)
   */
-  playlistInit();
-
-});
+  playlistInit()
+})

--- a/scripts/intro.js
+++ b/scripts/intro.js
@@ -1,25 +1,25 @@
+/* eslint-env jquery, browser */
+/* global relative */
 /**
  * Introduction if user is new or has not visited in a month.
  */
 
-import { introJs } from 'intro.js';
-import moment from 'moment';
-import i18n from './i18n.js';
-import Cookie from 'js-cookie';
-
+import { introJs } from 'intro.js'
+import moment from 'moment'
+import i18n from './i18n.js'
+import Cookie from 'js-cookie'
 
 // event handler: tour is wanted
-const yesButton = $('.intro-question .btn-success');
-yesButton.click(startTour);
-$('.top-menu a.intro').click(startTour);
+const yesButton = $('.intro-question .btn-success')
+yesButton.click(startTour)
+$('.top-menu a.intro').click(startTour)
 
-
-const question = $('.intro-question');
+const question = $('.intro-question')
 let tour, lastVisit
 try {
-  tour = localStorage.getItem('tour');
+  tour = localStorage.getItem('tour')
   // TODO: remove Cookie when migration to localStorage is complete
-  lastVisit = localStorage.getItem('last visit') || Cookie.get('last visit');
+  lastVisit = localStorage.getItem('last visit') || Cookie.get('last visit')
   if (lastVisit) {
     lastVisit = moment(lastVisit)
   }
@@ -27,53 +27,50 @@ try {
   // no support for localStorage
   // => do not show "want to take tour" every time
   console.warn('no localStorage support')
-  lastVisit = moment();
+  lastVisit = moment()
 }
-const now = moment();
+const now = moment()
 
 i18n.on('initialized', () => {
   if (tour === 'front page') {
-    showFrontPageIntro();
-  } else if (tour === 'lesson index'){
-    showLessonIndexIntro();
-  } else if (tour === 'lesson'){
-    showLessonIntro();
+    showFrontPageIntro()
+  } else if (tour === 'lesson index') {
+    showLessonIndexIntro()
+  } else if (tour === 'lesson') {
+    showLessonIntro()
   } else if (!lastVisit) {
     // never visited
     // ask if tour is wanted
-    question.modal();
+    question.modal()
   } else {
     // check if it's been more than a month since last visit
     if (lastVisit.add(30, 'days') < now) {
       // not visited in 30 days (time to refresh)
-      const questionBody = $('.intro-question .modal-body > p');
-      questionBody.text("Seems like it's a while since you've been here. Would you like a tour?"); // FIXME: translate
-      question.modal();
+      const questionBody = $('.intro-question .modal-body > p')
+      questionBody.text("Seems like it's a while since you've been here. Would you like a tour?") // FIXME: translate
+      question.modal()
     }
   }
-});
-
+})
 
 // update "last visit"
-localStorage.setItem('last visit',  now.format());
+localStorage.setItem('last visit', now.format())
 
+function startTour () {
+  question.modal('hide')
 
-function startTour() {
-  question.modal('hide');
-
-  localStorage.setItem('entry page',  window.location.href);
+  localStorage.setItem('entry page', window.location.href)
   if (!window.thisIsTheIndex) {
     // redirect -> start intro
-    localStorage.setItem('tour',  'front page');
-    window.location.href = relative('/');
+    localStorage.setItem('tour', 'front page')
+    window.location.href = relative('/')
   } else {
-    showFrontPageIntro();
+    showFrontPageIntro()
   }
 }
 
-
-function showFrontPageIntro(){
-  localStorage.removeItem('tour');
+function showFrontPageIntro () {
+  localStorage.removeItem('tour')
   introJs()
   .setOptions({
     nextLabel: i18n.t('next'),
@@ -95,17 +92,16 @@ function showFrontPageIntro(){
 
   })
   .start()
-  .oncomplete(function(){
+  .oncomplete(function () {
     // take to python page
-    localStorage.setItem('tour',  'lesson index');
-    window.location.href = 'python';
+    localStorage.setItem('tour', 'lesson index')
+    window.location.href = 'python'
   })
-  .onexit(tourDone);
+  .onexit(tourDone)
 }
 
-
-function showLessonIndexIntro(){
-  localStorage.removeItem('tour');
+function showLessonIndexIntro () {
+  localStorage.removeItem('tour')
   introJs()
   .setOptions({
     nextLabel: i18n.t('next'),
@@ -125,17 +121,16 @@ function showLessonIndexIntro(){
     }]
   })
   .start()
-  .oncomplete(function(){
+  .oncomplete(function () {
     // take to python page
-    localStorage.setItem('tour', 'lesson');
-    window.location.href = i18n.t('intro.lessonIndex.nextUrl');
+    localStorage.setItem('tour', 'lesson')
+    window.location.href = i18n.t('intro.lessonIndex.nextUrl')
   })
-  .onexit(tourDone);
+  .onexit(tourDone)
 }
 
-
-function showLessonIntro(){
-  localStorage.removeItem('tour');
+function showLessonIntro () {
+  localStorage.removeItem('tour')
   introJs()
   .setOptions({
     nextLabel: i18n.t('next'),
@@ -153,14 +148,13 @@ function showLessonIntro(){
     }]
   })
   .start()
-  .oncomplete(tourDone);
+  .oncomplete(tourDone)
 }
 
-
-function tourDone(){
-  const entry = localStorage.getItem('entry page');
-  localStorage.removeItem('entry page');
+function tourDone () {
+  const entry = localStorage.getItem('entry page')
+  localStorage.removeItem('entry page')
   if (entry !== undefined && entry !== window.location.href) {
-    window.location.href = entry;
+    window.location.href = entry
   }
 }

--- a/scripts/lesson-hover.js
+++ b/scripts/lesson-hover.js
@@ -1,30 +1,29 @@
+/* eslint-env jquery, browser */
 /**
  * show introduction to lesson on :hover
  */
 
-const SELECTOR = 'a > li.lesson';
-const CONTAINER = '.lessonIntro';
+const SELECTOR = 'a > li.lesson'
+const CONTAINER = '.lessonIntro'
 
-
-$(SELECTOR).hover(showIntro, hideIntro);
-
+$(SELECTOR).hover(showIntro, hideIntro)
 
 function showIntro () {
-  const elm = $(this).parent();
-  const url = elm.attr('href');
+  const elm = $(this).parent()
+  const url = elm.attr('href')
   if (!url || url.search(/^http/) === 0) {
-    return;
+    return
   }
 
-  const container = $('<div />');
-  container.addClass(CONTAINER.replace('.', ''));
-  $('body').append(container);
+  const container = $('<div />')
+  container.addClass(CONTAINER.replace('.', ''))
+  $('body').append(container)
 
   $.ajax(url)
     .then(filterIntro)
     .then(filterImgs(dirname(url)))
     .then(filterContent)
-    .then(createPopover(elm));
+    .then(createPopover(elm))
 }
 
 /**
@@ -32,11 +31,11 @@ function showIntro () {
  */
 function filterIntro (data) {
   // ? is ungreedy match
-  var m = data.match(/<section class="intro"[\s\S]+?<\/section>/g);
+  var m = data.match(/<section class="intro"[\s\S]+?<\/section>/g)
   if (!m) {
-    return '';
+    return ''
   }
-  return m[0];
+  return m[0]
 }
 
 /**
@@ -45,7 +44,7 @@ function filterIntro (data) {
 function filterImgs (dir) {
   return function (data) {
     // src="not_starting_with/slash"
-    return data.replace(/src="([^\/][^"]+)"/g, 'src="'+ dir +'$1"');
+    return data.replace(/src="([^\/][^"]+)"/g, 'src="' + dir + '$1"')
   }
 }
 
@@ -53,50 +52,50 @@ function filterImgs (dir) {
  * get paragraphs and figures
  */
 function filterContent (data) {
-  const intro = {};
-  intro.text = $(data).find('p, pre');
-  intro.img = $(data).find('figure > img');
+  const intro = {}
+  intro.text = $(data).find('p, pre')
+  intro.img = $(data).find('figure > img')
   if (intro.text.length === 0) {
-    intro.text = null;
+    intro.text = null
   }
   if (intro.img.length === 0) {
-    intro.img = null;
+    intro.img = null
   }
   if (intro.img || intro.text) {
-    return intro;
+    return intro
   }
 }
 
 /**
  * functional Intro element
  */
-function Intro(data) {
-  const elm = $('<div />');
+function Intro (data) {
+  const elm = $('<div />')
   if (data.text) {
     elm.append('<div class="text" />')
-    $('.text', elm).append(data.text);
+    $('.text', elm).append(data.text)
     if (!data.img) {
-      $('.text', elm).css('width', '100%');
+      $('.text', elm).css('width', '100%')
     }
   }
   if (data.img) {
     elm.append('<div class="img" />')
-    $('.img', elm).append(data.img);
+    $('.img', elm).append(data.img)
     if (!data.text) {
-      $('.text', elm).css('width', '100%');
+      $('.text', elm).css('width', '100%')
     }
   }
-  return elm;
+  return elm
 }
 
 /**
  * opens a popover with the intro
  */
-let timeout;
+let timeout
 function createPopover (elm) {
   return function (data) {
     if (!data) {
-      return;
+      return
     }
     elm.popover({
       animate: true,
@@ -105,10 +104,10 @@ function createPopover (elm) {
       trigger: 'manual',
       html: true,
       content: Intro(data)
-    });
+    })
     // debounce
-    clearTimeout(timeout);
-    timeout = setTimeout(() => elm.popover('show'), 200);
+    clearTimeout(timeout)
+    timeout = setTimeout(() => elm.popover('show'), 200)
   }
 }
 
@@ -116,13 +115,13 @@ function createPopover (elm) {
  * remove all intro popovers
  */
 function hideIntro () {
-  clearTimeout(timeout);
-  $(CONTAINER).remove();
+  clearTimeout(timeout)
+  $(CONTAINER).remove()
 }
 
 /**
  * /path/name.html -> /path/
  */
 function dirname (url) {
-  return url.replace(/\/[^\/]+$/, '/');
+  return url.replace(/\/[^\/]+$/, '/')
 }

--- a/scripts/playlist.js
+++ b/scripts/playlist.js
@@ -1,3 +1,4 @@
+/* eslint-env jquery, browser */
 /**
  * Client side logic for playlists.
  *
@@ -5,23 +6,23 @@
  * - Keep track of position in playlist.
  */
 
-import i18n from './i18n.js';
+import i18n from './i18n.js'
 
-let t;
+let t
 i18n.on('initialized', () => {
-  t = i18n.getFixedT();
+  t = i18n.getFixedT()
 
   /**
    * If in lesson of playlist
    */
-  var playlist = JSON.parse(localStorage.getItem('playlist'));
+  var playlist = JSON.parse(localStorage.getItem('playlist'))
   if (playlist) {
     if (indexOf(playlist.lessons, window.location.href) !== undefined) {
       // current lesson is this very page -> add navigation
-      addNavigation(playlist);
+      addNavigation(playlist)
     } else {
       // remove playlist from localStorage, we are no longer in a playlist
-      localStorage.removeItem('playlist');
+      localStorage.removeItem('playlist')
     }
   }
 })
@@ -30,97 +31,96 @@ export default function init () {
   /**
    * show/hide playlist
    */
-  $('.playlist > li').click(function(){
-    $('.' + this.id).slideToggle();
-  });
+  $('.playlist > li').click(function () {
+    $('.' + this.id).slideToggle()
+  })
 
   /**
    * save playlist to localStorage when clicking lesson in playlist
    */
-  $('.playlist a').click(function(event) {
-    event.preventDefault();
-    var url = $(this).attr('href');
+  $('.playlist a').click(function (event) {
+    event.preventDefault()
+    var url = $(this).attr('href')
     if (url.search(/^http/) === 0) {
       // external lesson
-      return;
+      return
     }
-    var playlist = getPlaylist(this);
-    localStorage.setItem('playlist', JSON.stringify(playlist));
-    window.location.href = this.attributes.href.value;
-  });
+    var playlist = getPlaylist(this)
+    localStorage.setItem('playlist', JSON.stringify(playlist))
+    window.location.href = this.attributes.href.value
+  })
 }
-
 
 /**
  * Create a playlist object from a playlist lesson link.
  */
-function getPlaylist(link) {
-  var parent = $(link).parent();
-  var res = {};
-  res.name = $('.name', parent).text();
-  res.lessons = getLessons(parent);
-  return res;
+function getPlaylist (link) {
+  var parent = $(link).parent()
+  var res = {}
+  res.name = $('.name', parent).text()
+  res.lessons = getLessons(parent)
+  return res
 }
 
-function getLessons(playlist) {
-  var base = window.location.href.replace('index.html', '');
-  var links = $('a', playlist);
-  return $.map(links, function(elm){
-    var url = base + elm.attributes.href.value;
-    var name = $('> li', elm).text();
-    return {url: url, name: name};
-  });
+function getLessons (playlist) {
+  var base = window.location.href.replace('index.html', '')
+  var links = $('a', playlist)
+  return $.map(links, function (elm) {
+    var url = base + elm.attributes.href.value
+    var name = $('> li', elm).text()
+    return {url: url, name: name}
+  })
 }
 
-function addNavigation(playlist) {
-  var navigation = '<div class="playlist-navigation">';
-  navigation += '<h1>'+ playlist.name +'</h1>';
+function addNavigation (playlist) {
+  var navigation = '<div class="playlist-navigation">'
+  navigation += '<h1>' + playlist.name + '</h1>'
 
-  navigation += '<ul class="pagination">';
-  navigation += '<li><a class="prev" data-i18n="title=prev" ';
-  navigation += 'title="'+ t('prev') +'">&laquo;</a></li>';
-  for (var i=0, l=playlist.lessons.length; i<l; ++i) {
-    var lesson = playlist.lessons[i];
-    navigation += '<li';
+  navigation += '<ul class="pagination">'
+  navigation += '<li><a class="prev" data-i18n="title=prev" '
+  navigation += 'title="' + t('prev') + '">&laquo</a></li>'
+  for (var i = 0, l = playlist.lessons.length; i < l; ++i) {
+    var lesson = playlist.lessons[i]
+    navigation += '<li'
     if (window.location.href === lesson.url) {
-      navigation += ' class="active"';
+      navigation += ' class="active"'
     }
-    navigation += '><a href="'+ lesson.url +'" ';
-    navigation += 'title="'+ lesson.name +'">';
-    navigation += '<span>'+ (i + 1) +'</span>';
-    navigation += '</a></li>';
+    navigation += '><a href="' + lesson.url + '" '
+    navigation += 'title="' + lesson.name + '">'
+    navigation += '<span>' + (i + 1) + '</span>'
+    navigation += '</a></li>'
   }
-  navigation += '<li><a class="next" data-i18n="title=next" ';
-  navigation += 'title="'+ t('next') +'">&raquo;</a></li>';
-  navigation += '</ul>';
-  navigation += '<div class="clearfix"></div></div>';
+  navigation += '<li><a class="next" data-i18n="title=next" '
+  navigation += 'title="' + t('next') + '">&raquo</a></li>'
+  navigation += '</ul>'
+  navigation += '<div class="clearfix"></div></div>'
 
-  $('header').parent().prepend(navigation);
-  $('.content').append(navigation);
+  $('header').parent().prepend(navigation)
+  $('.content').append(navigation)
 
-  $('.playlist-navigation select').change(function(){
-    window.location.href = this.value;
-  });
+  $('.playlist-navigation select').change(function () {
+    window.location.href = this.value
+  })
 
-  $('.playlist-navigation a').click(function(){
-    var i = indexOf(playlist.lessons, window.location.href);
+  $('.playlist-navigation a').click(function () {
+    var i = indexOf(playlist.lessons, window.location.href)
     if ($(this).hasClass('prev')) {
-      i -= 1;
+      i -= 1
     } else if ($(this).hasClass('next')) {
-      i += 1;
+      i += 1
     } else { return }  // not next/prev button
     if (playlist.lessons[i]) {
-      var url = playlist.lessons[i].url;
-      localStorage.setItem('playlist', JSON.stringify(playlist));
-      window.location.href = url;
+      var url = playlist.lessons[i].url
+      localStorage.setItem('playlist', JSON.stringify(playlist))
+      window.location.href = url
     }
   })
 }
 
-function indexOf(lessons, current) {
-  for (var i=0, l=lessons.length; i<l; ++i) {
+function indexOf (lessons, current) {
+  for (var i = 0, l = lessons.length; i < l; ++i) {
     if (lessons[i].url === current) {
-      return i;
+      return i
     }
   }
 }

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -1,73 +1,70 @@
+/* eslint-env jquery, browser */
+/* global relative */
 // lunr search engine
 var lunr = require('lunr')
-require('lunr-no/lunr.stemmer.support.js')(lunr);
-require('lunr-no')(lunr);
-
+require('lunr-no/lunr.stemmer.support.js')(lunr)
+require('lunr-no')(lunr)
 
 // for is not a stopword in this context
-var words = lunr.no.stopWordFilter.stopWords.elements;
-words.splice(words.indexOf('for'), 1);
+var words = lunr.no.stopWordFilter.stopWords.elements
+words.splice(words.indexOf('for'), 1)
 
 // download index if not already downloaded
-function downloadIndex(){
+function downloadIndex () {
   if (global.index === undefined) {
     $.ajax(relative('searchIndex.json'))
-      .done(function(data){
-        if (typeof(data) === 'string') {
+      .done(function (data) {
+        if (typeof data === 'string') {
           // parse data if served as text string (local file)
-          data = JSON.parse(data);
+          data = JSON.parse(data)
         }
-        global.index = lunr.Index.load(data);
-    });
+        global.index = lunr.Index.load(data)
+      })
   }
 }
-
 
 // download search index when focusing search input
-var searchInput = $('.search input');
-searchInput.on('focus', downloadIndex);
-
+var searchInput = $('.search input')
+searchInput.on('focus', downloadIndex)
 
 // search when typing
-var timeout;
-searchInput.on('input', function(event){
-  var value = $(this).val();
-  if (global.index !== undefined && value.length > 0){
+var timeout
+searchInput.on('input', function (event) {
+  var value = $(this).val()
+  if (global.index !== undefined && value.length > 0) {
     // debounce
-    clearTimeout(timeout);
-    timeout = setTimeout(function(){
-      if (value == searchInput.val()){
-        $('div.search').show();
-        $('.search > .results > li').remove();
-        var results = global.index.search(value);
-        global.res = results;
-        var defers = results.slice(0, 10).map(getResult);
-        defers.map(drawResult);
+    clearTimeout(timeout)
+    timeout = setTimeout(function () {
+      if (value === searchInput.val()) {
+        $('div.search').show()
+        $('.search > .results > li').remove()
+        var results = global.index.search(value)
+        global.res = results
+        var defers = results.slice(0, 10).map(getResult)
+        defers.map(drawResult)
       }
-    }, 200);
+    }, 200)
   }
-  if (value.length == 0){
-    $('div.search').hide();
+  if (value.length === 0) {
+    $('div.search').hide()
   }
-});
-
+})
 
 // draw search results
-function drawResult(defer){
-  defer.done(function(res){
-    var html = '<li><a href="' + res.url + '">';
-    html += '<h2>' + res.title + '</h2>';
-    html += '<p>' + res.content + '</p>';
-    html += '</a></li>';
-    $('.search > .results').append(html);
-  });
+function drawResult (defer) {
+  defer.done(function (res) {
+    var html = '<li><a href="' + res.url + '">'
+    html += '<h2>' + res.title + '</h2>'
+    html += '<p>' + res.content + '</p>'
+    html += '</a></li>'
+    $('.search > .results').append(html)
+  })
 }
 
-
 // fetches title and content of search result
-function getResult(searchResult){
-  var chain = $.Deferred();
-  var defer = $.Deferred();
+function getResult (searchResult) {
+  var chain = $.Deferred()
+  var defer = $.Deferred()
 
   chain.resolve(searchResult)
   .then(getPage)
@@ -75,58 +72,54 @@ function getResult(searchResult){
   .then(getTitle)
   .then(getContent)
   .then(cleanContent)
-  .then(defer.resolve);
+  .then(defer.resolve)
 
-  return defer.promise();
+  return defer.promise()
 }
 
 // get html of searchResult.ref
-function getPage(searchResult){
-  var url = searchResult.ref.replace('.md', '.html');
-  searchResult.url = relative(url);
-  var promise = $.ajax(searchResult.url).then(function(data){
-    searchResult.html = data;
-    return searchResult;
-  });
-  return promise;
+function getPage (searchResult) {
+  var url = searchResult.ref.replace('.md', '.html')
+  searchResult.url = relative(url)
+  var promise = $.ajax(searchResult.url).then(function (data) {
+    searchResult.html = data
+    return searchResult
+  })
+  return promise
 }
-
 
 // remove <img> from html string
-function removeImg(searchResult){
-  var html = searchResult.html;
-  var img = new RegExp(/<img[^>]*>/g);
+function removeImg (searchResult) {
+  var html = searchResult.html
+  var img = new RegExp(/<img[^>]*>/g)
   while (html.search(img) !== -1) {
-    html = html.replace(img, '');
+    html = html.replace(img, '')
   }
-  searchResult.html = html;
-  return searchResult;
+  searchResult.html = html
+  return searchResult
 }
-
 
 // remove <*> from content string
-function cleanContent(searchResult){
-  var content = searchResult.content;
-  var element = new RegExp(/<[^>]*>/g);
+function cleanContent (searchResult) {
+  var content = searchResult.content
+  var element = new RegExp(/<[^>]*>/g)
   while (content.search(element) !== -1) {
-    content = content.replace(element, '');
+    content = content.replace(element, '')
   }
-  searchResult.content = content;
-  return searchResult;
+  searchResult.content = content
+  return searchResult
 }
 
-
 // get title of html string
-function getTitle(searchResult){
-  var title = $(searchResult.html).next('title').text();
+function getTitle (searchResult) {
+  var title = $(searchResult.html).next('title').text()
   // 'title | YourCodeClubName' => 'title'
-  searchResult.title = title.replace(/ \| .*/, '');
-  return searchResult;
+  searchResult.title = title.replace(/ \| .*/, '')
+  return searchResult
 }
 
-
 // get title of html string
-function getContent(searchResult){
-  searchResult.content = $(searchResult.html).find('.content > *').text();
-  return searchResult;
+function getContent (searchResult) {
+  searchResult.content = $(searchResult.html).find('.content > *').text()
+  return searchResult
 }

--- a/tools.js
+++ b/tools.js
@@ -1,48 +1,46 @@
 // read front matter on demand
-var matter = require('gray-matter');
-var path = require('path');
-var fs = require('fs');
-var config = require('./config.js');
+var matter = require('gray-matter')
+var path = require('path')
+var fs = require('fs')
+var config = require('./config.js')
 
 /** Returns true if file exists */
-function isFile(dir, file){
-  var fullPath = path.join(config.sourceRoot, dir, file);
+function isFile (dir, file) {
+  var fullPath = path.join(config.sourceRoot, dir, file)
   try {
-    fs.statSync(fullPath);
+    fs.statSync(fullPath)
   } catch (e) {
-    return false;
+    return false
   }
-  return true;
+  return true
 }
 
 /** read front-matter from file, fail gracefully. */
-function frontmatter(filename) {
-  var filepath = path.join(config.lessonRoot, config.sourceFolder, filename);
-  var m;
+function frontmatter (filename) {
+  var filepath = path.join(config.lessonRoot, config.sourceFolder, filename)
+  var m
   try {
-    m = matter.read(filepath);
+    m = matter.read(filepath)
   } catch (e) {
-    return {};
+    return {}
   }
-  return m.data;
+  return m.data
 }
-
 
 /**
  * remove files from build which have external set
  */
-function removeExternal(files, _, done) {
-  Object.keys(files).forEach(function(key){
+function removeExternal (files, _, done) {
+  Object.keys(files).forEach(function (key) {
     if (files[key].external) {
-      delete files[key];
+      delete files[key]
     }
-  });
-  done();
+  })
+  done()
 }
-
 
 module.exports = {
   isFile: isFile,
   frontmatter: frontmatter,
   removeExternal: removeExternal
-};
+}

--- a/utils/fix_code_blocks.js
+++ b/utils/fix_code_blocks.js
@@ -2,16 +2,16 @@
  * fixes code blocks in lists, after change from pandoc to markdown-it
  */
 
-var globby = require("globby")
-var fs = require("fs")
+var globby = require('globby')
+var fs = require('fs')
 
-var files = globby.sync("src/**/*.md")
+var files = globby.sync('src/**/*.md')
 
 files.forEach(fixCodeBlocks)
 
-function fixCodeBlocks(file) {
-  var r = /\r\n\r\n\r\n    ```/g
-  var rr = "\r\n\r\n    ```"
-  var content = fs.readFileSync(file, "utf8")
+function fixCodeBlocks (file) {
+  var r = /\r\n\r\n\r\n {4}```/g
+  var rr = '\r\n\r\n {4}```'
+  var content = fs.readFileSync(file, 'utf8')
   fs.writeFileSync(file, content.replace(r, rr))
 }


### PR DESCRIPTION
All scripts (server- and client-side) are transformed by babel, therefore [automatic semicolon insertion](https://medium.com/@kentcdodds/semicolons-in-javascript-a-preference-dd8fc8b80895#.bpqo2dre6) is not an issue.

[standard](http://standardjs.com/) provides a clean style and finds errors ([like this one](https://github.com/arve0/codeclub_lesson_builder/commit/fb2678d13802de5bc379f72a6b0f5cb947440d9e#diff-ba210a9157252cc983268fdc3aa3ed52L209), `deployProc` not defined) up front. This PR adds a lint task (`npm run lint`) and re-formats the js-files.