### PR TITLE
Extend link-check timeout

### DIFF
--- a/check-links.js
+++ b/check-links.js
@@ -58,7 +58,7 @@ module.exports = function (start) {
         done: done,
         error: error,
         headers: { 'user-agent': 'codeclub_lesson_builder' },
-        timeout: 10000
+        timeout: 30000
       }  // spider options
 
       // text spider for HTML, CSS, etc


### PR DESCRIPTION
Extend link-check timeout from 10s to 30s to avoid report of broken links.